### PR TITLE
Refactor to reduce code repetition

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 'use strict';
-
 const util = require('util');
 
 const toString = Object.prototype.toString;

--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
 'use strict';
+
+const util = require('util');
+
 const toString = Object.prototype.toString;
 const getObjectType = x => toString.call(x).slice(8, -1);
 const isOfType = type => x => typeof x === type; // eslint-disable-line valid-typeof
@@ -151,7 +154,7 @@ is.inRange = (x, range) => {
 		return x >= Math.min.apply(null, range) && x <= Math.max.apply(null, range);
 	}
 
-	throw new TypeError('Invalid range');
+	throw new TypeError(`Invalid range: ${util.inspect}`);
 };
 
 module.exports = is;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 'use strict';
 const toString = Object.prototype.toString;
 const getObjectType = x => toString.call(x).slice(8, -1);
-const isOfType = type => x => getObjectType(x) === type;
+const isOfType = type => x => typeof x === type; // eslint-disable-line valid-typeof
+const isObjectOfType = type => x => getObjectType(x) === type;
 
 const is = value => {
 	if (value == null) { // eslint-disable-line no-eq-null, eqeqeq
@@ -30,7 +31,7 @@ const is = value => {
 		return 'symbol';
 	}
 
-	if (type === 'function') {
+	if (is.function(value)) {
 		return 'Function';
 	}
 
@@ -54,12 +55,53 @@ const is = value => {
 	return 'Object';
 };
 
-is.undefined = x => typeof x === 'undefined';
+is.undefined = isOfType('undefined');
 is.null = x => x === null;
-is.string = x => typeof x === 'string';
-is.number = x => typeof x === 'number';
-is.boolean = x => typeof x === 'boolean';
-is.symbol = x => typeof x === 'symbol';
+is.string = isOfType('string');
+is.number = isOfType('number');
+is.boolean = isOfType('boolean');
+is.symbol = isOfType('symbol');
+
+is.array = Array.isArray;
+is.function = isOfType('function');
+is.buffer = Buffer.isBuffer;
+
+const isObject = x => typeof x === 'object';
+
+is.object = x => !is.nullOrUndefined(x) && (is.function(x) || isObject(x));
+
+is.nativePromise = isObjectOfType('Promise');
+
+const hasPromiseAPI = x =>
+	!is.null(x) &&
+	isObject(x) &&
+	is.function(x.then) &&
+	is.function(x.catch);
+
+is.promise = x => is.nativePromise(x) || hasPromiseAPI(x);
+
+is.regExp = isObjectOfType('RegExp');
+is.date = isObjectOfType('Date');
+is.error = isObjectOfType('Error');
+is.map = isObjectOfType('Map');
+is.set = isObjectOfType('Set');
+is.weakMap = isObjectOfType('WeakMap');
+is.weakSet = isObjectOfType('WeakSet');
+
+is.int8Array = isObjectOfType('Int8Array');
+is.uint8Array = isObjectOfType('Uint8Array');
+is.uint8ClampedArray = isObjectOfType('Uint8ClampedArray');
+is.int16Array = isObjectOfType('Int16Array');
+is.uint16Array = isObjectOfType('Uint16Array');
+is.int32Array = isObjectOfType('Int32Array');
+is.uint32Array = isObjectOfType('Uint32Array');
+is.float32Array = isObjectOfType('Float32Array');
+is.float64Array = isObjectOfType('Float64Array');
+
+is.arrayBuffer = isObjectOfType('ArrayBuffer');
+is.sharedArrayBuffer = isObjectOfType('SharedArrayBuffer');
+
+is.nan = Number.isNaN;
 is.nullOrUndefined = x => is.null(x) || is.undefined(x);
 
 const primitiveTypes = new Set([
@@ -71,44 +113,6 @@ const primitiveTypes = new Set([
 ]);
 is.primitive = x => is.null(x) || primitiveTypes.has(typeof x);
 
-is.array = Array.isArray;
-is.function = x => typeof x === 'function';
-is.buffer = Buffer.isBuffer;
-
-is.object = x => !is.nullOrUndefined(x) && (is.function(x) || typeof x === 'object');
-
-is.nativePromise = isOfType('Promise');
-
-const hasPromiseAPI = x =>
-	!is.null(x) &&
-	typeof x === 'object' &&
-	is.function(x.then) &&
-	is.function(x.catch);
-
-is.promise = x => is.nativePromise(x) || hasPromiseAPI(x);
-
-is.regExp = isOfType('RegExp');
-is.date = isOfType('Date');
-is.error = isOfType('Error');
-is.map = isOfType('Map');
-is.set = isOfType('Set');
-is.weakMap = isOfType('WeakMap');
-is.weakSet = isOfType('WeakSet');
-
-is.int8Array = isOfType('Int8Array');
-is.uint8Array = isOfType('Uint8Array');
-is.uint8ClampedArray = isOfType('Uint8ClampedArray');
-is.int16Array = isOfType('Int16Array');
-is.uint16Array = isOfType('Uint16Array');
-is.int32Array = isOfType('Int32Array');
-is.uint32Array = isOfType('Uint32Array');
-is.float32Array = isOfType('Float32Array');
-is.float64Array = isOfType('Float64Array');
-
-is.arrayBuffer = isOfType('ArrayBuffer');
-is.sharedArrayBuffer = isOfType('SharedArrayBuffer');
-
-is.nan = Number.isNaN;
 is.integer = Number.isInteger;
 
 is.plainObject = x => {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 const toString = Object.prototype.toString;
 const getObjectType = x => toString.call(x).slice(8, -1);
+const isOfType = type => x => getObjectType(x) === type;
 
 const is = value => {
 	if (value == null) { // eslint-disable-line no-eq-null, eqeqeq
@@ -59,69 +60,55 @@ is.string = x => typeof x === 'string';
 is.number = x => typeof x === 'number';
 is.boolean = x => typeof x === 'boolean';
 is.symbol = x => typeof x === 'symbol';
+is.nullOrUndefined = x => is.null(x) || is.undefined(x);
+
+const primitiveTypes = new Set([
+	'undefined',
+	'string',
+	'number',
+	'boolean',
+	'symbol'
+]);
+is.primitive = x => is.null(x) || primitiveTypes.has(typeof x);
 
 is.array = Array.isArray;
 is.function = x => typeof x === 'function';
 is.buffer = Buffer.isBuffer;
 
-is.object = x => {
-	const type = typeof x;
-	return x !== null && (type === 'object' || type === 'function');
-};
+is.object = x => !is.nullOrUndefined(x) && (is.function(x) || typeof x === 'object');
 
-is.nativePromise = x => getObjectType(x) === 'Promise';
+is.nativePromise = isOfType('Promise');
 
-is.promise = x => {
-	return is.nativePromise(x) ||
-		(
-			x !== null &&
-			typeof x === 'object' &&
-			typeof x.then === 'function' &&
-			typeof x.catch === 'function'
-		);
-};
+const hasPromiseAPI = x =>
+	!is.null(x) &&
+	typeof x === 'object' &&
+	is.function(x.then) &&
+	is.function(x.catch);
 
-is.regExp = x => getObjectType(x) === 'RegExp';
-is.date = x => getObjectType(x) === 'Date';
-is.error = x => getObjectType(x) === 'Error';
-is.map = x => getObjectType(x) === 'Map';
-is.set = x => getObjectType(x) === 'Set';
-is.weakMap = x => getObjectType(x) === 'WeakMap';
-is.weakSet = x => getObjectType(x) === 'WeakSet';
+is.promise = x => is.nativePromise(x) || hasPromiseAPI(x);
 
-is.int8Array = x => getObjectType(x) === 'Int8Array';
-is.uint8Array = x => getObjectType(x) === 'Uint8Array';
-is.uint8ClampedArray = x => getObjectType(x) === 'Uint8ClampedArray';
-is.int16Array = x => getObjectType(x) === 'Int16Array';
-is.uint16Array = x => getObjectType(x) === 'Uint16Array';
-is.int32Array = x => getObjectType(x) === 'Int32Array';
-is.uint32Array = x => getObjectType(x) === 'Uint32Array';
-is.float32Array = x => getObjectType(x) === 'Float32Array';
-is.float64Array = x => getObjectType(x) === 'Float64Array';
+is.regExp = isOfType('RegExp');
+is.date = isOfType('Date');
+is.error = isOfType('Error');
+is.map = isOfType('Map');
+is.set = isOfType('Set');
+is.weakMap = isOfType('WeakMap');
+is.weakSet = isOfType('WeakSet');
 
-is.arrayBuffer = x => getObjectType(x) === 'ArrayBuffer';
+is.int8Array = isOfType('Int8Array');
+is.uint8Array = isOfType('Uint8Array');
+is.uint8ClampedArray = isOfType('Uint8ClampedArray');
+is.int16Array = isOfType('Int16Array');
+is.uint16Array = isOfType('Uint16Array');
+is.int32Array = isOfType('Int32Array');
+is.uint32Array = isOfType('Uint32Array');
+is.float32Array = isOfType('Float32Array');
+is.float64Array = isOfType('Float64Array');
 
-is.sharedArrayBuffer = x => {
-	try {
-		return getObjectType(x) === 'SharedArrayBuffer';
-	} catch (err) {
-		return false;
-	}
-};
+is.arrayBuffer = isOfType('ArrayBuffer');
+is.sharedArrayBuffer = isOfType('SharedArrayBuffer');
 
 is.nan = Number.isNaN;
-is.nullOrUndefined = x => x === null || typeof x === 'undefined';
-
-is.primitive = x => {
-	const type = typeof x;
-	return x === null ||
-		type === 'undefined' ||
-		type === 'string' ||
-		type === 'number' ||
-		type === 'boolean' ||
-		type === 'symbol';
-};
-
 is.integer = Number.isInteger;
 
 is.plainObject = x => {
@@ -133,9 +120,9 @@ is.plainObject = x => {
 			prototype === Object.getPrototypeOf({}));
 };
 
-is.iterable = x => !is.null(x) && !is.undefined(x) && typeof x[Symbol.iterator] === 'function';
+is.iterable = x => !is.nullOrUndefined(x) && is.function(x[Symbol.iterator]);
 
-is.class = x => typeof x === 'function' && x.toString().startsWith('class ');
+is.class = x => is.function(x) && x.toString().startsWith('class ');
 
 const typedArrayTypes = new Set([
 	'Int8Array',

--- a/test.js
+++ b/test.js
@@ -333,6 +333,14 @@ test('is.inRange', t => {
 	});
 
 	t.throws(() => {
+		m.inRange(0, []);
+	});
+
+	t.throws(() => {
 		m.inRange(0, [5]);
+	});
+
+	t.throws(() => {
+		m.inRange(0, [1, 2, 3]);
 	});
 });

--- a/test.js
+++ b/test.js
@@ -329,10 +329,10 @@ test('is.inRange', t => {
 	t.false(m.inRange(-3, -2));
 
 	t.throws(() => {
-		m.inRange(0)
+		m.inRange(0);
 	});
 
 	t.throws(() => {
-		m.inRange(0, [5])
+		m.inRange(0, [5]);
 	});
 });

--- a/test.js
+++ b/test.js
@@ -10,7 +10,11 @@ const ErrorSubclassFixture = class extends Error {};
 const types = new Map([
 	['undefined', undefined],
 	['null', null],
-	['string', '🦄'],
+	['string', [
+		'🦄',
+		'hello world',
+		''
+	]],
 	['number', [
 		6,
 		1.4,
@@ -247,9 +251,7 @@ test('is.primitive', t => {
 		Symbol('🦄')
 	];
 
-	for (const el of primitives) {
-		t.true(m.primitive(el));
-	}
+	primitives.forEach(el => t.true(m.primitive(el)));
 });
 
 test('is.integer', t => {
@@ -320,13 +322,15 @@ test('is.inRange', t => {
 
 	t.true(m.inRange(x, 10));
 	t.true(m.inRange(0, 0));
+	t.true(m.inRange(-2, -3));
 	t.false(m.inRange(x, 2));
+	t.false(m.inRange(-3, -2));
 
-	t.throws(() => {
-		t.true(m.inRange(0));
-	});
+	t.throws(() =>
+		t.true(m.inRange(0))
+	);
 
-	t.throws(() => {
-		t.true(m.inRange(0, [5]));
-	});
+	t.throws(() =>
+		t.true(m.inRange(0, [5]))
+	);
 });

--- a/test.js
+++ b/test.js
@@ -251,7 +251,9 @@ test('is.primitive', t => {
 		Symbol('🦄')
 	];
 
-	primitives.forEach(el => t.true(m.primitive(el)));
+	for (const el of primitives) {
+		t.true(m.primitive(el));
+	}
 });
 
 test('is.integer', t => {
@@ -326,11 +328,11 @@ test('is.inRange', t => {
 	t.false(m.inRange(x, 2));
 	t.false(m.inRange(-3, -2));
 
-	t.throws(() =>
-		t.true(m.inRange(0))
-	);
+	t.throws(() => {
+		m.inRange(0)
+	});
 
-	t.throws(() =>
-		t.true(m.inRange(0, [5]))
-	);
+	t.throws(() => {
+		m.inRange(0, [5])
+	});
 });


### PR DESCRIPTION
* slight styling changes
* use existing methods whenever possible (f.e `is.function` instead of `typeof x === 'function`)
* change all occurrences of `is.something = x => getObjectType(x) === 'Something)` to `is.something = isTypeOf('Something')` using a factory method
* removed unnecessary `try/catch` in `is.sharedArrayBuffer`.

closes #5