### PR TITLE
Add is.even() and is.odd()

### DIFF
--- a/index.js
+++ b/index.js
@@ -178,6 +178,10 @@ is.domElement = x => is.object(x) && x.nodeType === NODE_TYPE_ELEMENT && is.stri
 
 is.infinite = x => x === Infinity || x === -Infinity;
 
+const isAbsoluteMod2 = value => x => is.integer(x) && Math.abs(x % 2) === value;
+is.even = isAbsoluteMod2(0);
+is.odd = isAbsoluteMod2(1);
+
 const isEmptyStringOrArray = x => (is.string(x) || is.array(x)) && x.length === 0;
 const isEmptyObject = x => !is.map(x) && !is.set(x) && is.object(x) && Object.keys(x).length === 0;
 const isEmptyMapOrSet = x => (is.map(x) || is.set(x)) && x.size === 0;

--- a/readme.md
+++ b/readme.md
@@ -165,6 +165,14 @@ Returns `true` if `value` is a DOM Element.
 
 Check if `value` is `Infinity` or `-Infinity`.
 
+##### .even(value)
+
+Returns `true` if `value` is an even integer.
+
+##### .odd(value)
+
+Returns `true` if `value` is an odd integer.
+
 ##### .empty(value)
 
 Returns `true` if `value` is falsy or an empty string, array, object, map, or set.

--- a/test.js
+++ b/test.js
@@ -409,6 +409,26 @@ test('is.infinite', t => {
 	testType(t, 'infinite', ['number']);
 });
 
+test('is.even', t => {
+	for (const el of [-6, 2, 4]) {
+		t.true(m.even(el));
+	}
+
+	for (const el of [-3, 1, 5]) {
+		t.false(m.even(el));
+	}
+});
+
+test('is.odd', t => {
+	for (const el of [-5, 7, 13]) {
+		t.true(m.odd(el));
+	}
+
+	for (const el of [-8, 8, 10]) {
+		t.false(m.odd(el));
+	}
+});
+
 test('is.empty', t => {
 	t.true(m.empty(null));
 	t.true(m.empty(undefined));


### PR DESCRIPTION
Intentionally left `even` and `odd` out of `types` in the tests for these ones. Integer / number values are growing in their need to be explicitly excluded from one another. Glad to add them if that's preferred. 

