### PR TITLE
Restore ability to use default export in CommonJS

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -247,3 +247,7 @@ Object.defineProperties(is, {
 });
 
 export default is; // tslint:disable-line:no-default-export
+
+// For CommonJS default export support
+module.exports = is;
+module.exports.default = is;


### PR DESCRIPTION
So you can use `require('is')` instead of `require('is').default`.

It's a hack, but it seems to work fine.