### PR TITLE
Add is.boundFunction()

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,21 @@ is.asyncFunction(() => {});
 // => false
 ```
 
+##### .boundFunction(value)
+
+Returns `true` for any `bound` function.
+
+```js
+is.boundFunction(() => {});
+// => true
+
+is.boundFunction(function () {}.bind(null));
+// => true
+
+is.boundFunction(function () {});
+// => false
+```
+
 ##### .map(value)
 ##### .set(value)
 ##### .weakMap(value)

--- a/source/index.ts
+++ b/source/index.ts
@@ -95,6 +95,7 @@ namespace is { // tslint:disable-line:no-namespace
 
 	export const generatorFunction = isFunctionOfType('GeneratorFunction');
 	export const asyncFunction = isFunctionOfType('AsyncFunction');
+	export const boundFunction = (value: any) => function_(value) && !value.hasOwnProperty('prototype');
 
 	export const regExp = isObjectOfType('RegExp');
 	export const date = isObjectOfType('Date');

--- a/source/tests/test.ts
+++ b/source/tests/test.ts
@@ -150,6 +150,13 @@ const types = new Map<string, Test>([
 			async () => {} // tslint:disable-line:no-empty
 		]
 	}],
+	['boundFunction', {
+		is: m.boundFunction,
+		fixtures: [
+			() => {}, // tslint:disable-line:no-empty
+			function () {}.bind(null), // tslint:disable-line:no-empty only-arrow-functions
+		]
+	}],
 	['map', {
 		is: m.map,
 		fixtures: [
@@ -362,7 +369,8 @@ test('is.array', t => {
 });
 
 test('is.function', t => {
-	testType(t, 'function', ['generatorFunction', 'asyncFunction']);
+	testType(t, 'function', ['generatorFunction', 'asyncFunction', 'boundFunction']);
+	t.false(m.boundFunction(function () {})); // tslint:disable-line:no-empty only-arrow-functions
 });
 
 test('is.buffer', t => {

--- a/source/tests/test.ts
+++ b/source/tests/test.ts
@@ -370,6 +370,9 @@ test('is.array', t => {
 
 test('is.function', t => {
 	testType(t, 'function', ['generatorFunction', 'asyncFunction', 'boundFunction']);
+});
+
+test('is.boundFunction', t => {
 	t.false(m.boundFunction(function () {})); // tslint:disable-line:no-empty only-arrow-functions
 });
 


### PR DESCRIPTION
Should fix #30 . I think having `is.boundFunction()` is more appropriate than having `is.arrowFunction()` considering that the use-case is to check if a function is already bound or not.