### PR TITLE
 Improve TS code by adding generics and removing `any` where applicable

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -111,7 +111,7 @@ function is(value: any): TypeName { // tslint:disable-line:only-arrow-functions
 }
 
 namespace is { // tslint:disable-line:no-namespace
-	const isObject = (value: object) => typeof value === 'object'; // tslint:disable-line:strict-type-predicates
+	const isObject = (value: any): value is object => typeof value === 'object';
 
 	// tslint:disable:variable-name
 	export const undefined = isOfType<undefined>('undefined');
@@ -137,7 +137,7 @@ namespace is { // tslint:disable-line:no-namespace
 
 	const hasPromiseAPI = (value: any): value is Promise<any> =>
 		!null_(value) &&
-		isObject(value) &&
+		isObject(value) as any &&
 		function_(value.then) &&
 		function_(value.catch);
 
@@ -246,7 +246,7 @@ namespace is { // tslint:disable-line:no-namespace
 	export const domElement = (value: any): value is DomElement => object(value) as any && value.nodeType === NODE_TYPE_ELEMENT && string(value.nodeName) &&
 		!plainObject(value) && DOM_PROPERTIES_TO_CHECK.every(property => property in value);
 
-	export const nodeStream = (value: any): value is NodeStream => !nullOrUndefined(value) && isObject(value) && function_(value.pipe);
+	export const nodeStream = (value: any): value is NodeStream => !nullOrUndefined(value) && isObject(value) as any && function_(value.pipe);
 
 	export const infinite = (value: any) => value === Infinity || value === -Infinity;
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -7,10 +7,12 @@ export interface ArrayLike {
 	length: number;
 }
 
-type Class<T = any> = { new(...args: any[]): T; };
+export interface Class<T = any> {
+	new(...args: any[]): T;
+}
 
-type DomElement = object & { nodeType: 1; nodeName: string }
-type NodeStream = object & { pipe: Function }
+type DomElement = object & { nodeType: 1; nodeName: string };
+type NodeStream = object & { pipe: Function };
 
 export const enum TypeName {
 	null = 'null',
@@ -109,7 +111,7 @@ function is(value: any): TypeName { // tslint:disable-line:only-arrow-functions
 }
 
 namespace is { // tslint:disable-line:no-namespace
-	const isObject = (value: object) => typeof value === 'object';
+	const isObject = (value: object) => typeof value === 'object'; // tslint:disable-line:strict-type-predicates
 
 	// tslint:disable:variable-name
 	export const undefined = isOfType<undefined>('undefined');
@@ -241,8 +243,8 @@ namespace is { // tslint:disable-line:no-namespace
 		'nodeValue'
 	];
 
-	export const domElement = (value: any): value is DomElement => value.nodeType === NODE_TYPE_ELEMENT && string(value.nodeName) &&
-		!plainObject(value) && DOM_PROPERTIES_TO_CHECK.every(property => property in value) && object(value);
+	export const domElement = (value: any): value is DomElement => object(value) as any && value.nodeType === NODE_TYPE_ELEMENT && string(value.nodeName) &&
+		!plainObject(value) && DOM_PROPERTIES_TO_CHECK.every(property => property in value);
 
 	export const nodeStream = (value: any): value is NodeStream => !nullOrUndefined(value) && isObject(value) && function_(value.pipe);
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -182,7 +182,7 @@ namespace is { // tslint:disable-line:no-namespace
 	export const integer = (value: number): value is number => Number.isInteger(value);
 	export const safeInteger = (value: number): value is number => Number.isSafeInteger(value);
 
-	export const plainObject = (value: any) => {
+	export const plainObject = (value: object) => {
 		// From: https://github.com/sindresorhus/is-plain-obj/blob/master/index.js
 		let prototype;
 
@@ -239,7 +239,7 @@ namespace is { // tslint:disable-line:no-namespace
 	export const domElement = (value: any) => object(value) && value.nodeType === NODE_TYPE_ELEMENT && string(value.nodeName) &&
 		!plainObject(value) && DOM_PROPERTIES_TO_CHECK.every(property => property in value);
 
-	export const nodeStream = (value: any) => !nullOrUndefined(value) && isObject(value) && function_(value.pipe);
+	export const nodeStream = (value: object) => !nullOrUndefined(value) && isObject(value) && function_(value.pipe);
 
 	export const infinite = (value: number) => value === Infinity || value === -Infinity;
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -129,7 +129,7 @@ namespace is { // tslint:disable-line:no-namespace
 
 	export const nullOrUndefined = (value: any): value is null | undefined => null_(value) || undefined(value);
 	export const object = (value: any): value is object => !nullOrUndefined(value) && (function_(value) || isObject(value));
-	export const iterable = <T = any>(value: any): value is IterableIterator<T> => !nullOrUndefined(value) && function_(value[Symbol.iterator]);
+	export const iterable = (value: any): value is IterableIterator<any> => !nullOrUndefined(value) && function_(value[Symbol.iterator]);
 	export const generator = (value: any): value is Generator => iterable(value) && function_(value.next) && function_(value.throw);
 
 	export const nativePromise = (value: any): value is Promise<any> =>
@@ -150,10 +150,10 @@ namespace is { // tslint:disable-line:no-namespace
 	export const regExp = isObjectOfType<RegExp>(TypeName.RegExp);
 	export const date = isObjectOfType<Date>(TypeName.Date);
 	export const error = isObjectOfType<Error>(TypeName.Error);
-	export const map = (value: Map<any, any>): value is Map<any, any> => isObjectOfType<Map<any, any>>(TypeName.Map)(value);
-	export const set = (value: Set<any>): value is Set<any> => isObjectOfType<Set<any>>(TypeName.Set)(value);
-	export const weakMap = (value: WeakMap<any, any>): value is WeakMap<any, any> => isObjectOfType<WeakMap<any, any>>(TypeName.WeakMap)(value);
-	export const weakSet = (value: WeakSet<any>): value is WeakSet<any> => isObjectOfType<WeakSet<any>>(TypeName.WeakSet)(value);
+	export const map = (value: any): value is Map<any, any> => isObjectOfType<Map<any, any>>(TypeName.Map)(value);
+	export const set = (value: any): value is Set<any> => isObjectOfType<Set<any>>(TypeName.Set)(value);
+	export const weakMap = (value: any): value is WeakMap<any, any> => isObjectOfType<WeakMap<any, any>>(TypeName.WeakMap)(value);
+	export const weakSet = (value: any): value is WeakSet<any> => isObjectOfType<WeakSet<any>>(TypeName.WeakSet)(value);
 
 	export const int8Array = isObjectOfType<Int8Array>(TypeName.Int8Array);
 	export const uint8Array = isObjectOfType<Uint8Array>(TypeName.Uint8Array);

--- a/source/index.ts
+++ b/source/index.ts
@@ -111,7 +111,7 @@ namespace is { // tslint:disable-line:no-namespace
 	export const string = isOfType<string>('string');
 	export const number = isOfType<number>('number');
 	export const function_ = isOfType<Function>('function');
-	export const null_ = (value: any): value is null => value === null;
+	export const null_ = (value: null | any): value is null => value === null;
 	export const class_ = (value: any) => function_(value) && value.toString().startsWith('class ');
 	export const boolean = (value: boolean): value is boolean => value === true || value === false;
 	export const symbol = isOfType<Symbol>('symbol');
@@ -120,10 +120,10 @@ namespace is { // tslint:disable-line:no-namespace
 	export const array = Array.isArray;
 	export const buffer = Buffer.isBuffer;
 
-	export const nullOrUndefined = (value: any): value is null | undefined => null_(value) || undefined(value);
+	export const nullOrUndefined = (value: null | undefined | any): value is null | undefined => null_(value) || undefined(value);
 	export const object = (value: object) => !nullOrUndefined(value) && (function_(value) || isObject(value));
-	export const iterable = (value: IterableIterator<any>): value is IterableIterator<any> => !nullOrUndefined(value) && function_(value[Symbol.iterator]);
-	export const generator = (value: any): value is Generator => iterable(value) && function_(value.next) && function_(value.throw);
+	export const iterable = <T = any>(value: IterableIterator<T>): value is IterableIterator<T> => !nullOrUndefined(value) && function_(value[Symbol.iterator]);
+	export const generator = (value: Generator): value is Generator => iterable(value as IterableIterator<any>) && function_(value.next) && function_(value.throw);
 
 	export const nativePromise = <T = any>(value: Promise<T>): value is Promise<T> =>
 		isObjectOfType<Promise<T>>(TypeName.Promise)(value);
@@ -236,10 +236,10 @@ namespace is { // tslint:disable-line:no-namespace
 		'nodeValue'
 	];
 
-	export const domElement = (value: any) => object(value) && value.nodeType === NODE_TYPE_ELEMENT && string(value.nodeName) &&
+	export const domElement = (value: object & { nodeType: 1; nodeName: string }) => object(value) && value.nodeType === NODE_TYPE_ELEMENT && string(value.nodeName) &&
 		!plainObject(value) && DOM_PROPERTIES_TO_CHECK.every(property => property in value);
 
-	export const nodeStream = (value: object) => !nullOrUndefined(value) && isObject(value) && function_(value.pipe);
+	export const nodeStream = (value: object & { pipe: Function }) => !nullOrUndefined(value) && isObject(value) && function_(value.pipe);
 
 	export const infinite = (value: number) => value === Infinity || value === -Infinity;
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -58,30 +58,25 @@ const getObjectType = (value: any): TypeName | null => {
 const isObjectOfType = <T>(type: TypeName) => (value: any): value is T => getObjectType(value) === type;
 
 function is(value: any): TypeName { // tslint:disable-line:only-arrow-functions
-	if (value === null) {
-		return TypeName.null;
+	switch (value) {
+		case null:
+			return TypeName.null;
+		case true:
+		case false:
+			return TypeName.boolean;
+		default:
 	}
 
-	if (value === true || value === false) {
-		return TypeName.boolean;
-	}
-
-	const type = typeof value;
-
-	if (type === 'undefined') {
-		return TypeName.undefined;
-	}
-
-	if (type === 'string') {
-		return TypeName.string;
-	}
-
-	if (type === 'number') {
-		return TypeName.number;
-	}
-
-	if (type === 'symbol') {
-		return TypeName.symbol;
+	switch (typeof value) {
+		case 'undefined':
+			return TypeName.undefined;
+		case 'string':
+			return TypeName.string;
+		case 'number':
+			return TypeName.number;
+		case 'symbol':
+			return TypeName.symbol;
+		default:
 	}
 
 	if (is.function_(value)) {
@@ -109,7 +104,7 @@ function is(value: any): TypeName { // tslint:disable-line:only-arrow-functions
 }
 
 namespace is { // tslint:disable-line:no-namespace
-	const isObject = (value: any) => typeof value === 'object';
+	const isObject = (value: object) => typeof value === 'object'; // tslint:disable-line:strict-type-predicates
 
 	// tslint:disable:variable-name
 	export const undefined = isOfType<undefined>('undefined');
@@ -118,7 +113,7 @@ namespace is { // tslint:disable-line:no-namespace
 	export const function_ = isOfType<Function>('function');
 	export const null_ = (value: any): value is null => value === null;
 	export const class_ = (value: any) => function_(value) && value.toString().startsWith('class ');
-	export const boolean = (value: any): value is boolean => value === true || value === false;
+	export const boolean = (value: boolean): value is boolean => value === true || value === false;
 	export const symbol = isOfType<Symbol>('symbol');
 	// tslint:enable:variable-name
 
@@ -126,32 +121,32 @@ namespace is { // tslint:disable-line:no-namespace
 	export const buffer = Buffer.isBuffer;
 
 	export const nullOrUndefined = (value: any): value is null | undefined => null_(value) || undefined(value);
-	export const object = (value: any) => !nullOrUndefined(value) && (function_(value) || isObject(value));
-	export const iterable = (value: any): value is Iterator<any> => !nullOrUndefined(value) && function_(value[Symbol.iterator]);
+	export const object = (value: object) => !nullOrUndefined(value) && (function_(value) || isObject(value));
+	export const iterable = (value: IterableIterator<any>): value is IterableIterator<any> => !nullOrUndefined(value) && function_(value[Symbol.iterator]);
 	export const generator = (value: any): value is Generator => iterable(value) && function_(value.next) && function_(value.throw);
 
-	export const nativePromise = isObjectOfType<Promise<any>>(TypeName.Promise);
+	export const nativePromise = <T = any>(value: Promise<T>): value is Promise<T> =>
+		isObjectOfType<Promise<T>>(TypeName.Promise)(value);
 
-	const hasPromiseAPI = (value: any): value is Promise<any> =>
+	const hasPromiseAPI = <T = any>(value: Promise<T>): value is Promise<T> =>
 		!null_(value) &&
 		isObject(value) &&
 		function_(value.then) &&
 		function_(value.catch);
 
-	export const promise = (value: any): value is Promise<any> => nativePromise(value) || hasPromiseAPI(value);
+	export const promise = <T = any>(value: Promise<T>): value is Promise<T> => nativePromise<T>(value) || hasPromiseAPI<T>(value);
 
-	const isFunctionOfType = <T>(type: TypeName) => isObjectOfType<T>(type);
-	export const generatorFunction = isFunctionOfType<GeneratorFunction>(TypeName.GeneratorFunction);
-	export const asyncFunction = isFunctionOfType<Function>(TypeName.AsyncFunction);
-	export const boundFunction = (value: any): value is Function => function_(value) && !value.hasOwnProperty('prototype');
+	export const generatorFunction = isObjectOfType<GeneratorFunction>(TypeName.GeneratorFunction);
+	export const asyncFunction = isObjectOfType<Function>(TypeName.AsyncFunction);
+	export const boundFunction = (value: Function): value is Function => function_(value) && !value.hasOwnProperty('prototype');
 
 	export const regExp = isObjectOfType<RegExp>(TypeName.RegExp);
 	export const date = isObjectOfType<Date>(TypeName.Date);
 	export const error = isObjectOfType<Error>(TypeName.Error);
-	export const map = isObjectOfType<Map<any, any>>(TypeName.Map);
-	export const set = isObjectOfType<Set<any>>(TypeName.Set);
-	export const weakMap = isObjectOfType<WeakMap<any, any>>(TypeName.WeakMap);
-	export const weakSet = isObjectOfType<WeakSet<any>>(TypeName.WeakSet);
+	export const map = <T1 = any, T2 = any>(value: Map<T1, T2>): value is Map<T1, T2> => isObjectOfType<Map<T1, T2>>(TypeName.Map)(value);
+	export const set = <T = any>(value: Set<T>): value is Set<T> => isObjectOfType<Set<T>>(TypeName.Set)(value);
+	export const weakMap = <T1 extends object = any, T2 = any>(value: WeakMap<T1, T2>): value is WeakMap<T1, T2> => isObjectOfType<WeakMap<T1, T2>>(TypeName.WeakMap)(value);
+	export const weakSet = <T extends object = any>(value: WeakSet<T>): value is WeakSet<T> => isObjectOfType<WeakSet<T>>(TypeName.WeakSet)(value);
 
 	export const int8Array = isObjectOfType<Int8Array>(TypeName.Int8Array);
 	export const uint8Array = isObjectOfType<Uint8Array>(TypeName.Uint8Array);
@@ -172,7 +167,7 @@ namespace is { // tslint:disable-line:no-namespace
 	export const truthy = (value: any) => Boolean(value);
 	export const falsy = (value: any) => !value;
 
-	export const nan = (value: any) => Number.isNaN(value);
+	export const nan = (value: number) => Number.isNaN(value);
 
 	const primitiveTypes = new Set([
 		'undefined',
@@ -182,10 +177,10 @@ namespace is { // tslint:disable-line:no-namespace
 		'symbol'
 	]);
 
-	export const primitive = (value: any): value is Primitive => null_(value) || primitiveTypes.has(typeof value);
+	export const primitive = (value: Primitive): value is Primitive => null_(value) || primitiveTypes.has(typeof value);
 
-	export const integer = (value: any): value is number => Number.isInteger(value);
-	export const safeInteger = (value: any): value is number => Number.isSafeInteger(value);
+	export const integer = (value: number): value is number => Number.isInteger(value);
+	export const safeInteger = (value: number): value is number => Number.isSafeInteger(value);
 
 	export const plainObject = (value: any) => {
 		// From: https://github.com/sindresorhus/is-plain-obj/blob/master/index.js
@@ -207,7 +202,7 @@ namespace is { // tslint:disable-line:no-namespace
 		TypeName.Float32Array,
 		TypeName.Float64Array
 	]);
-	export const typedArray = (value: any): value is TypedArray => {
+	export const typedArray = (value: TypedArray): value is TypedArray => {
 		const objectType = getObjectType(value);
 
 		if (objectType === null) {
@@ -217,8 +212,8 @@ namespace is { // tslint:disable-line:no-namespace
 		return typedArrayTypes.has(objectType);
 	};
 
-	const isValidLength = (value: any) => safeInteger(value) && value > -1;
-	export const arrayLike = (value: any): value is ArrayLike => !nullOrUndefined(value) && !function_(value) && isValidLength(value.length);
+	const isValidLength = (value: number) => safeInteger(value) && value > -1;
+	export const arrayLike = (value: ArrayLike): value is ArrayLike => !nullOrUndefined(value) && !function_(value) && isValidLength(value.length);
 
 	export const inRange = (value: number, range: number | number[]) => {
 		if (number(range)) {
@@ -246,22 +241,22 @@ namespace is { // tslint:disable-line:no-namespace
 
 	export const nodeStream = (value: any) => !nullOrUndefined(value) && isObject(value) && function_(value.pipe);
 
-	export const infinite = (value: any) => value === Infinity || value === -Infinity;
+	export const infinite = (value: number) => value === Infinity || value === -Infinity;
 
 	const isAbsoluteMod2 = (value: number) => (rem: number) => integer(rem) && Math.abs(rem % 2) === value;
 	export const even = isAbsoluteMod2(0);
 	export const odd = isAbsoluteMod2(1);
 
-	const isWhiteSpaceString = (value: any) => string(value) && /\S/.test(value) === false;
-	const isEmptyStringOrArray = (value: any) => (string(value) || array(value)) && value.length === 0;
+	const isWhiteSpaceString = (value: string) => string(value) && /\S/.test(value) === false;
+	const isEmptyStringOrArray = (value: string | any[]) => (string(value) || array(value)) && value.length === 0;
 	const isEmptyObject = (value: any) => !map(value) && !set(value) && object(value) && Object.keys(value).length === 0;
 	const isEmptyMapOrSet = (value: any) => (map(value) || set(value)) && value.size === 0;
 
 	export const empty = (value: any) => falsy(value) || isEmptyStringOrArray(value) || isEmptyObject(value) || isEmptyMapOrSet(value);
 	export const emptyOrWhitespace = (value: any) => empty(value) || isWhiteSpaceString(value);
 
-	type ArrayMethod = (fn: (value: any, index: number, array: any[]) => boolean, thisArg?: any) => boolean;
-	const predicateOnArray = (method: ArrayMethod, predicate: any, values: any[]) => {
+	type ArrayMethod = <T>(fn: (value: T, index: number, array: T[]) => boolean, thisArg?: any) => boolean;
+	const predicateOnArray = <T = any>(method: ArrayMethod, predicate: T, values: any[]) => {
 		if (function_(predicate) === false) {
 			throw new TypeError(`Invalid predicate: ${util.inspect(predicate)}`);
 		}
@@ -274,8 +269,8 @@ namespace is { // tslint:disable-line:no-namespace
 	};
 
 	// tslint:disable variable-name
-	export const any = (predicate: any, ...values: any[]) => predicateOnArray(Array.prototype.some, predicate, values);
-	export const all = (predicate: any, ...values: any[]) => predicateOnArray(Array.prototype.every, predicate, values);
+	export const any = <T>(predicate: T, ...values: any[]) => predicateOnArray(Array.prototype.some, predicate, values);
+	export const all = <T>(predicate: T, ...values: any[]) => predicateOnArray(Array.prototype.every, predicate, values);
 	// tslint:enable variable-name
 }
 

--- a/source/tests/test.ts
+++ b/source/tests/test.ts
@@ -322,7 +322,7 @@ const types = new Map<string, Test>([
 		]
 	}],
 	['infinite', {
-		is:  m.infinite,
+		is: m.infinite,
 		fixtures: [
 			Infinity,
 			-Infinity
@@ -582,15 +582,15 @@ test('is.plainObject', t => {
 });
 
 test('is.iterable', t => {
-	t.true(m.iterable(''));
-	t.true(m.iterable([]));
-	t.true(m.iterable(new Map()));
-	t.false(m.iterable(null));
-	t.false(m.iterable(undefined));
-	t.false(m.iterable(0));
-	t.false(m.iterable(NaN));
-	t.false(m.iterable(Infinity));
-	t.false(m.iterable({}));
+	t.true(m.iterable('' as any));
+	t.true(m.iterable([] as any));
+	t.true(m.iterable(new Map() as any));
+	t.false(m.iterable(null as any));
+	t.false(m.iterable(undefined as any));
+	t.false(m.iterable(0 as any));
+	t.false(m.iterable(NaN as any));
+	t.false(m.iterable(Infinity as any));
+	t.false(m.iterable({} as any));
 });
 
 test('is.class', t => {
@@ -623,9 +623,9 @@ test('is.typedArray', t => {
 		t.true(m.typedArray(el));
 	}
 
-	t.false(m.typedArray(new ArrayBuffer(1)));
-	t.false(m.typedArray([]));
-	t.false(m.typedArray({}));
+	t.false(m.typedArray(new ArrayBuffer(1) as any));
+	t.false(m.typedArray([] as any));
+	t.false(m.typedArray({} as any));
 });
 
 test('is.arrayLike', t => {
@@ -635,9 +635,9 @@ test('is.arrayLike', t => {
 	t.true(m.arrayLike([]));
 	t.true(m.arrayLike('unicorn'));
 
-	t.false(m.arrayLike({}));
+	t.false(m.arrayLike({} as any));
 	t.false(m.arrayLike(() => {})); // tslint:disable-line:no-empty
-	t.false(m.arrayLike(new Map()));
+	t.false(m.arrayLike(new Map() as any));
 });
 
 test('is.inRange', t => {

--- a/source/tests/test.ts
+++ b/source/tests/test.ts
@@ -582,15 +582,15 @@ test('is.plainObject', t => {
 });
 
 test('is.iterable', t => {
-	t.true(m.iterable('' as any));
-	t.true(m.iterable([] as any));
-	t.true(m.iterable(new Map() as any));
-	t.false(m.iterable(null as any));
-	t.false(m.iterable(undefined as any));
-	t.false(m.iterable(0 as any));
-	t.false(m.iterable(NaN as any));
-	t.false(m.iterable(Infinity as any));
-	t.false(m.iterable({} as any));
+	t.true(m.iterable(''));
+	t.true(m.iterable([]));
+	t.true(m.iterable(new Map()));
+	t.false(m.iterable(null));
+	t.false(m.iterable(undefined));
+	t.false(m.iterable(0));
+	t.false(m.iterable(NaN));
+	t.false(m.iterable(Infinity));
+	t.false(m.iterable({}));
 });
 
 test('is.class', t => {
@@ -623,9 +623,9 @@ test('is.typedArray', t => {
 		t.true(m.typedArray(el));
 	}
 
-	t.false(m.typedArray(new ArrayBuffer(1) as any));
-	t.false(m.typedArray([] as any));
-	t.false(m.typedArray({} as any));
+	t.false(m.typedArray(new ArrayBuffer(1)));
+	t.false(m.typedArray([]));
+	t.false(m.typedArray({}));
 });
 
 test('is.arrayLike', t => {
@@ -635,9 +635,9 @@ test('is.arrayLike', t => {
 	t.true(m.arrayLike([]));
 	t.true(m.arrayLike('unicorn'));
 
-	t.false(m.arrayLike({} as any));
+	t.false(m.arrayLike({}));
 	t.false(m.arrayLike(() => {})); // tslint:disable-line:no-empty
-	t.false(m.arrayLike(new Map() as any));
+	t.false(m.arrayLike(new Map()));
 });
 
 test('is.inRange', t => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,16 +13,11 @@
 			"es2017.sharedmemory"
 		],
 		"stripInternal": true,
-		"noImplicitAny": true,
+		"strict": true,
 		"noImplicitReturns": true,
-		"noImplicitThis": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"noFallthroughCasesInSwitch": true,
-		"strictNullChecks": true,
-		"strictFunctionTypes": true,
-		"strictPropertyInitialization": true,
-		"alwaysStrict": true,
 		"esModuleInterop": true
 	},
 	"exclude": [


### PR DESCRIPTION
This is in response to: https://github.com/sindresorhus/ow/pull/68#issuecomment-385262882

The switch at the top is debatable but should be faster and is also shorter 🙆
Generally it is more an improvement for TS-users and we directly see if our typings are not set correctly, as to be seen in the tests for instance 🕵️
(If you're also interested why `() => {}` is ArrayLike (=== has a length) check this out: [Function.length](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/length))

Please bear with me for throwing plenty of those `any`s in in the first place: [Blame](https://github.com/sindresorhus/is/blame/master/source/index.ts) 🙈🙉

