### PR TITLE
Add `is.observable`

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,17 +43,23 @@
 		"verify",
 		"compare"
 	],
+	"dependencies": {
+		"symbol-observable": "^1.2.0"
+	},
 	"devDependencies": {
 		"@types/jsdom": "^11.0.4",
 		"@types/node": "^9.6.0",
 		"@types/tempy": "^0.1.0",
+		"@types/zen-observable": "^0.5.3",
 		"ava": "*",
 		"del-cli": "^1.1.0",
 		"jsdom": "^11.6.2",
+		"rxjs": "^6.0.0",
 		"tempy": "^0.2.1",
 		"tslint": "^5.9.1",
 		"tslint-xo": "^0.7.0",
-		"typescript": "^2.8.1"
+		"typescript": "^2.8.1",
+		"zen-observable": "^0.8.8"
 	},
 	"types": "dist/index.d.ts"
 }

--- a/readme.md
+++ b/readme.md
@@ -261,6 +261,16 @@ is.nodeStream(fs.createReadStream('unicorn.png'));
 //=> true
 ```
 
+##### .observable(value)
+
+Returns `true` if `value` is an `Observable`.
+
+```js
+const Observable = require('rxjs').Observable;
+is.observable(new Observable());
+//=> true
+```
+
 ##### .infinite(value)
 
 Check if `value` is `Infinity` or `-Infinity`.

--- a/source/index.ts
+++ b/source/index.ts
@@ -1,4 +1,5 @@
 import * as util from 'util';
+import symbolObservable from 'symbol-observable';
 
 type TypedArray = Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array | Float32Array | Float64Array;
 type Primitive = null | undefined | string | number | boolean | Symbol;
@@ -17,6 +18,7 @@ export const enum TypeName {
 	Function = 'Function',
 	GeneratorFunction = 'GeneratorFunction',
 	AsyncFunction = 'AsyncFunction',
+	Observable = 'Observable',
 	Array = 'Array',
 	Buffer = 'Buffer',
 	Object = 'Object',
@@ -86,6 +88,10 @@ function is(value: any): TypeName { // tslint:disable-line:only-arrow-functions
 
 	if (is.function_(value)) {
 		return TypeName.Function;
+	}
+
+	if (is.observable(value)) {
+		return TypeName.Observable;
 	}
 
 	if (Array.isArray(value)) {
@@ -244,7 +250,8 @@ namespace is { // tslint:disable-line:no-namespace
 	export const domElement = (value: any) => object(value) && value.nodeType === NODE_TYPE_ELEMENT && string(value.nodeName) &&
 		!plainObject(value) && DOM_PROPERTIES_TO_CHECK.every(property => property in value);
 
-	export const nodeStream = (value: any) => !nullOrUndefined(value) && isObject(value) && function_(value.pipe);
+	export const observable = (value: any) => Boolean(value && value[symbolObservable] && value === value[symbolObservable]());
+	export const nodeStream = (value: any) => !nullOrUndefined(value) && isObject(value) && function_(value.pipe) && !observable(value);
 
 	export const infinite = (value: any) => value === Infinity || value === -Infinity;
 

--- a/source/tests/test.ts
+++ b/source/tests/test.ts
@@ -5,6 +5,8 @@ import * as util from 'util';
 import * as tempy from 'tempy';
 import test, {TestContext, Context} from 'ava';
 import {JSDOM} from 'jsdom';
+import {Subject, Observable} from 'rxjs';
+import ZenObservable from 'zen-observable';
 import m from '..';
 
 const isNode8orHigher = Number(process.versions.node.split('.')[0]) >= 8;
@@ -319,6 +321,14 @@ const types = new Map<string, Test>([
 			new Stream.Transform(),
 			new Stream.Stream(),
 			new Stream.Writable()
+		]
+	}],
+	['observable', {
+		is: m.observable,
+		fixtures: [
+			new Observable(),
+			new Subject(),
+			new ZenObservable(() => {})	// tslint:disable-line:no-empty
 		]
 	}],
 	['infinite', {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
 		"module": "commonjs",
 		"moduleResolution": "node",
 		"declaration": true,
+		"skipLibCheck": true,
 		"pretty": true,
 		"newLine": "lf",
 		"lib": [


### PR DESCRIPTION
Added `is.observable` which uses the exact same implementation as [is-observable](https://github.com/sindresorhus/is-observable).

@sindresorhus Would be fine to use `is-observable` directly as a dependency though.