### PR TITLE
Fix parameter naming of `isAbsoluteMod2` function.

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -260,7 +260,7 @@ namespace is { // tslint:disable-line:no-namespace
 
 	export const infinite = (value: any) => value === Infinity || value === -Infinity;
 
-	const isAbsoluteMod2 = (value: number) => (rem: number) => integer(rem) && Math.abs(rem % 2) === value;
+	const isAbsoluteMod2 = (rem: number) => (value: number) => integer(value) && Math.abs(value % 2) === rem;
 	export const even = isAbsoluteMod2(0);
 	export const odd = isAbsoluteMod2(1);
 


### PR DESCRIPTION
The [functions that check of odd/even numbers](https://github.com/sindresorhus/is/blob/master/source/index.ts#L263) appear to have their parameters named incorrectly:

    const isAbsoluteMod2 = (value: number) => (rem: number) => integer(rem) && Math.abs(rem % 2) === value;

Surely this ought to be:

    const isAbsoluteMod2 = (rem: number) => (value: number) => integer(value) && Math.abs(value % 2) === rem;

As you can see, the code works and wouldn't fail any tests, because the implementation takes into account the badly-named parameters, but for the code to be easier to read, it really ought to be the right way around.

This PR fixes that.