### PR TITLE
Drop duplicate export

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -366,6 +366,5 @@ Object.defineProperties(is, {
 	}
 });
 
-
 module.exports = is; // For CommonJS default export support
 export default is;

--- a/source/index.ts
+++ b/source/index.ts
@@ -366,8 +366,6 @@ Object.defineProperties(is, {
 	}
 });
 
-export default is;
 
-// For CommonJS default export support
-module.exports = is;
-module.exports.default = is;
+module.exports = is; // For CommonJS default export support
+export default is;


### PR DESCRIPTION
`module.exports.default` and `export default` are equivalent, so just use `export default` at the end.

## TS input

```diff
- export default is;
  module.exports = is;
- module.exports.default = is;
+ export default is;
```

## JS output

```diff
- exports.default = is;
  module.exports = is;
+ exports.default = is;
- module.exports.default = is;
```

## Live test

Before: https://www.typescriptlang.org/play/#src=export%20default%20is%3B%0D%0Amodule.exports%20%3D%20is%3B%0D%0Amodule.exports.default%20%3D%20is%3B
After: https://www.typescriptlang.org/play/#src=module.exports%20%3D%20is%3B%0D%0Aexport%20default%20is%3B