### PR TITLE
Test coverage for `is(value)`

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -16,6 +16,7 @@ export const enum TypeName {
 	number = 'number',
 	symbol = 'symbol',
 	Function = 'Function',
+	Generator = 'Generator',
 	GeneratorFunction = 'GeneratorFunction',
 	AsyncFunction = 'AsyncFunction',
 	Observable = 'Observable',

--- a/test/test.ts
+++ b/test/test.ts
@@ -801,12 +801,19 @@ test('is.domElement', t => {
 	testType(t, 'domElement');
 	t.false(is.domElement({nodeType: 1, nodeName: 'div'}));
 
-	t.is(is(createDomElement('div')), 'HTMLDivElement');
-	t.is(is(createDomElement('input')), 'HTMLInputElement');
-	t.is(is(createDomElement('span')), 'HTMLSpanElement');
-	t.is(is(createDomElement('img')), 'HTMLImageElement');
-	t.is(is(createDomElement('canvas')), 'HTMLCanvasElement');
-	t.is(is(createDomElement('script')), 'HTMLScriptElement');
+	const htmlTagNameToTypeName = {
+		div: 'HTMLDivElement',
+		input: 'HTMLInputElement',
+		span: 'HTMLSpanElement',
+		img: 'HTMLImageElement',
+		canvas: 'HTMLCanvasElement',
+		script: 'HTMLScriptElement'
+	};
+
+	Object.entries(htmlTagNameToTypeName).forEach(([tagName, typeName]) => {
+		const domElement = createDomElement(tagName);
+		t.is(is(domElement), typeName);
+	});
 });
 
 test('is.observable', t => {

--- a/test/test.ts
+++ b/test/test.ts
@@ -808,10 +808,10 @@ test('is.domElement', t => {
 		script: 'HTMLScriptElement'
 	};
 
-	Object.entries(htmlTagNameToTypeName).forEach(([tagName, typeName]) => {
+	for (const [tagName, typeName] of Object.entries(htmlTagNameToTypeName)) {
 		const domElement = createDomElement(tagName);
 		t.is(is(domElement), typeName);
-	});
+	}
 });
 
 test('is.observable', t => {

--- a/test/test.ts
+++ b/test/test.ts
@@ -21,9 +21,7 @@ const createDomElement = (element: string) => document.createElement(element);
 
 interface Test {
 	fixtures: unknown[];
-
-	// Cannot be TypeName because TypeName.GeneratorFunction does not match 'Generator'
-	typename?: TypeName | 'Generator';
+	typename?: TypeName;
 	is(value: unknown): boolean;
 }
 
@@ -181,7 +179,7 @@ const types = new Map<string, Test>([
 				yield 4;
 			})()
 		],
-		typename: 'Generator'
+		typename: TypeName.Generator
 	}],
 	['generatorFunction', {
 		is: is.generatorFunction,

--- a/test/test.ts
+++ b/test/test.ts
@@ -800,7 +800,13 @@ test('is.inRange', t => {
 test('is.domElement', t => {
 	testType(t, 'domElement');
 	t.false(is.domElement({nodeType: 1, nodeName: 'div'}));
+
 	t.is(is(createDomElement('div')), 'HTMLDivElement');
+	t.is(is(createDomElement('input')), 'HTMLInputElement');
+	t.is(is(createDomElement('span')), 'HTMLSpanElement');
+	t.is(is(createDomElement('img')), 'HTMLImageElement');
+	t.is(is(createDomElement('canvas')), 'HTMLCanvasElement');
+	t.is(is(createDomElement('script')), 'HTMLScriptElement');
 });
 
 test('is.observable', t => {


### PR DESCRIPTION
Fixes #7.

I chose a slightly different path than the one suggested in the issue. There were only two minor annoyances that you might want cleaned up / tweaked:

* For some reason, `TypeName.GeneratorFunction` has a value of `'GeneratorFunction'` but the value returned from `is` is `'Generator'`. If the actual string of `'GeneratorFunction'` is not being used, could we change it to `'Generator'`?
* The various HTML elements all have different types that are not included in `TypeName`. They were also mixed into a single test type of `domElement` which meant that the `typename` helper would not work properly. I don't think anything needs to be changed here; just calling it out.
