### PR TITLE
Make `is.number(NaN)` return false

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,7 @@ Keep in mind that [functions are objects too](https://developer.mozilla.org/en-U
 
 ##### .numericString(value)
 
-Returns `true` for a string that represents a number satisfying `is.number`.
+Returns `true` for a string that represents a number satisfying `is.number`, for example, `'42'` and `'-8.3'`.
 
 Note: `'NaN'` returns `false`, but `'Infinity'` and `'-Infinity'` return `true`.
 

--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ All the below methods accept a value and returns a boolean for whether the value
 ##### .string(value)
 ##### .number(value)
 
-Note: `is.number(NaN)` returns `false`.
+Note: `is.number(NaN)` returns `false`. This intentionally deviates from `typeof` behavior to increase user-friendliness of `is` type checks.
 
 ##### .boolean(value)
 ##### .symbol(value)
@@ -86,7 +86,7 @@ Keep in mind that [functions are objects too](https://developer.mozilla.org/en-U
 
 ##### .numericString(value)
 
-Returns `true` for a string that represents a number. For example, `'42'` and `'-8'`.
+Returns `true` for a string that represents a number satisfying `is.number`.
 
 Note: `'NaN'` returns `false`, but `'Infinity'` and `'-Infinity'` return `true`.
 

--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,9 @@ All the below methods accept a value and returns a boolean for whether the value
 ##### .null(value)
 ##### .string(value)
 ##### .number(value)
+
+Note: `is.number(NaN)` returns `false`.
+
 ##### .boolean(value)
 ##### .symbol(value)
 ##### .bigint(value)

--- a/source/index.ts
+++ b/source/index.ts
@@ -118,7 +118,7 @@ const isObject = (value: unknown): value is object => typeof value === 'object';
 
 is.undefined = isOfType<undefined>('undefined');
 is.string = isOfType<string>('string');
-is.number = isOfType<number>('number');
+is.number = (value: unknown): value is number => isOfType<number>('number')(value) && !is.nan(value);
 is.bigint = isOfType<bigint>('bigint');
 
 // eslint-disable-next-line @typescript-eslint/ban-types

--- a/source/index.ts
+++ b/source/index.ts
@@ -118,7 +118,10 @@ const isObject = (value: unknown): value is object => typeof value === 'object';
 
 is.undefined = isOfType<undefined>('undefined');
 is.string = isOfType<string>('string');
-is.number = (value: unknown): value is number => isOfType<number>('number')(value) && !is.nan(value);
+
+const isNumberType = isOfType<number>('number');
+is.number = (value: unknown): value is number => isNumberType(value) && !is.nan(value);
+
 is.bigint = isOfType<bigint>('bigint');
 
 // eslint-disable-next-line @typescript-eslint/ban-types

--- a/test/test.ts
+++ b/test/test.ts
@@ -494,7 +494,7 @@ test('is.string', t => {
 });
 
 test('is.number', t => {
-	testType(t, 'number', ['nan', 'integer', 'safeInteger', 'infinite']);
+	testType(t, 'number', ['integer', 'safeInteger', 'infinite']);
 });
 
 // TODO: Nodejs 10 only


### PR DESCRIPTION
Fixes #63 

> I'm been thinking about this a lot, and I'm now leaning towards just changing `is.number()` to not accept `NaN`. It can work if we clearly document that it does not accept `NaN`. Just because `typeof` is broken, doesn't mean that we can't do better. This package is all about creating the most user-friendly type checks.

And so, `is.number(NaN)` returns `false`. No further changes, so `-Infinite` and `Infinite` and `-0` still return `true`.