### PR TITLE
Fix unnecessary global inclusion of dom lib

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -1,6 +1,3 @@
-/// <reference lib="esnext"/>
-/// <reference lib="dom"/>
-
 // TODO: Use the `URL` global when targeting Node.js 10
 const URLGlobal = typeof URL === 'undefined' ? require('url').URL : URL;
 


### PR DESCRIPTION
TypeScript packages depending on this and importing `@sindresorhus/is`
end up with the lib.dom.d.ts in global scope thanks to the deleted
lines.

That's almost never what any user of the package would want, and it has
the side effect of putting a slew of common variable names (including
the variable names "event" and "name" and "parent") into a global scope.

It's particularly sinister because on many of these, TypeScript won't
complain, for example "name" is of type never.