### PR TITLE
Fix a readme link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -448,7 +448,7 @@ The most common mistakes I noticed in these modules was using `instanceof` for t
 
 Available as part of the Tidelift Subscription.
 
-The maintainers of @sindresorhus/is and thousands of other packages are working with Tidelift to deliver commercial support and maintenance for the open source dependencies you use to build your applications. Save time, reduce risk, and improve code health, while paying the maintainers of the exact dependencies you use. [Learn more.](https://tidelift.com/subscription/pkg/npm--sindresorhus-is?utm_source=npm-sindresorhus-is&utm_medium=referral&utm_campaign=enterprise&utm_term=repo)
+The maintainers of @sindresorhus/is and thousands of other packages are working with Tidelift to deliver commercial support and maintenance for the open source dependencies you use to build your applications. Save time, reduce risk, and improve code health, while paying the maintainers of the exact dependencies you use. [Learn more.](https://tidelift.com/subscription/pkg/npm-sindresorhus-is?utm_source=npm-sindresorhus-is&utm_medium=referral&utm_campaign=enterprise&utm_term=repo)
 
 
 ## Related


### PR DESCRIPTION
I noticed a bug in our UI that had `--` in the link when it should only be `-`. I've fixed that so it links to the live page.