### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,20 +46,20 @@
 		"types"
 	],
 	"devDependencies": {
-		"@sindresorhus/tsconfig": "^0.6.0",
+		"@sindresorhus/tsconfig": "^0.7.0",
 		"@types/jsdom": "^12.2.4",
 		"@types/node": "^12.12.6",
 		"@types/zen-observable": "^0.8.0",
-		"@typescript-eslint/eslint-plugin": "^1.11.0",
-		"@typescript-eslint/parser": "^1.11.0",
+		"@typescript-eslint/eslint-plugin": "^2.17.0",
+		"@typescript-eslint/parser": "^2.17.0",
 		"ava": "^2.1.0",
 		"del-cli": "^2.0.0",
-		"eslint-config-xo-typescript": "^0.15.0",
+		"eslint-config-xo-typescript": "^0.24.1",
 		"jsdom": "^15.0.0",
 		"rxjs": "^6.4.0",
 		"tempy": "^0.3.0",
 		"ts-node": "^8.3.0",
-		"typescript": "^3.7.2",
+		"typescript": "^3.7.5",
 		"xo": "^0.25.3",
 		"zen-observable": "^0.8.8"
 	},
@@ -80,6 +80,9 @@
 		"extensions": [
 			"ts"
 		],
+		"parserOptions": {
+			"project": "./tsconfig.xo.json"
+		},
 		"globals": [
 			"BigInt",
 			"BigInt64Array",

--- a/source/index.ts
+++ b/source/index.ts
@@ -278,8 +278,8 @@ is.typedArray = (value: unknown): value is TypedArray => {
 };
 
 export interface ArrayLike<T> {
-	readonly length: number;
 	readonly [index: number]: T;
+	readonly length: number;
 }
 
 const isValidLength = (value: unknown): value is number => is.safeInteger(value) && value >= 0;

--- a/test/test.ts
+++ b/test/test.ts
@@ -457,7 +457,7 @@ const testType = (t: ExecutionContext, type: string, exclude?: string[]) => {
 	for (const [key, {fixtures}] of types) {
 		// TODO: Automatically exclude value types in other tests that we have in the current one.
 		// Could reduce the use of `exclude`.
-		if (exclude && exclude.includes(key)) {
+		if (exclude?.includes(key)) {
 			continue;
 		}
 

--- a/tsconfig.xo.json
+++ b/tsconfig.xo.json
@@ -1,0 +1,6 @@
+{
+	"extends": "./tsconfig.json",
+	"include": [
+		"test"
+	]
+}


### PR DESCRIPTION
Attempts to fix linter parsing issues stemming from changes in typescript v3.7.

- Upgrade `eslint`-related packages.
- Upgrade `typescript` and related `tsconfig`.
- Fixes linting errors due to upgraded rules.
- Note that you might need to remove `node_modules` and run `npm install` again to properly clear linting caches.
- Include the `test` directory in the typescript project to fix the below parsing error.

> Parsing error: `"parserOptions.project"` has been set for `@typescript-eslint/parser`.
> The file does not match your project config: `test/test.ts`.
> The file must be included in at least one of the projects provided.

See

- https://github.com/typescript-eslint/typescript-eslint/pull/1045
- https://github.com/microsoft/TypeScript/commits/v3.7.5
- https://github.com/sindresorhus/tsconfig/issues/7
- https://github.com/xojs/eslint-config-xo-typescript/issues/20