### PR TITLE
Fix #109: `is.numericString` behaves correctly on whitespaces

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -130,7 +130,7 @@ is.boolean = (value: unknown): value is boolean => value === true || value === f
 is.symbol = isOfType<symbol>('symbol');
 
 is.numericString = (value: unknown): value is string =>
-	is.string(value) && value.length > 0 && !Number.isNaN(Number(value));
+	is.string(value) && !is.emptyStringOrWhitespace(value) && !Number.isNaN(Number(value));
 
 is.array = Array.isArray;
 is.buffer = (value: unknown): value is Buffer => (value as any)?.constructor?.isBuffer?.(value) ?? false;

--- a/test/test.ts
+++ b/test/test.ts
@@ -124,7 +124,8 @@ const types = new Map<string, Test>([
 		fixtures: [
 			'5',
 			'-3.2',
-			'Infinity'
+			'Infinity',
+			'0x56'
 		],
 		typename: TypeName.string,
 		typeDescription: AssertionTypeDescription.numericString
@@ -627,6 +628,8 @@ test('is.symbol', t => {
 test('is.numericString', t => {
 	testType(t, 'numericString');
 	t.false(is.numericString(''));
+	t.false(is.numericString(' '));
+	t.false(is.numericString(' \t\t\n'));
 	t.false(is.numericString(1));
 	t.throws(() => {
 		assert.numericString('');


### PR DESCRIPTION
I have added the required test cases. @gioragutt Let me know if I you want me to add more test cases. 