### PR TITLE
Make the `is()` function type-safe

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -66,6 +66,10 @@ const objectTypeNames = [
 
 type ObjectTypeName = typeof objectTypeNames[number];
 
+function isObjectTypeName(name: unknown): name is ObjectTypeName {
+	return objectTypeNames.includes(name as ObjectTypeName);
+}
+
 const primitiveTypeNames = [
 	'null',
 	'undefined',
@@ -100,9 +104,14 @@ function isOfType<T extends Primitive | Function>(type: PrimitiveTypeName | 'fun
 
 const {toString} = Object.prototype;
 const getObjectType = (value: unknown): ObjectTypeName | undefined => {
-	const objectName = toString.call(value).slice(8, -1);
-	if (objectName) {
-		return objectName as ObjectTypeName;
+	const objectTypeName = toString.call(value).slice(8, -1);
+
+	if (/HTML\w+Element/.test(objectTypeName) && is.domElement(value)) {
+		return 'HTMLElement';
+	}
+
+	if (isObjectTypeName(objectTypeName)) {
+		return objectTypeName;
 	}
 
 	return undefined;

--- a/test/test.ts
+++ b/test/test.ts
@@ -1284,10 +1284,10 @@ test('is.domElement', t => {
 		'script'
 	];
 
-	tagNames.forEach(tagName => {
+	for (const tagName of tagNames) {
 		const domElement = createDomElement(tagName);
 		t.is(is(domElement), 'HTMLElement');
-	});
+	}
 });
 
 test('is.observable', t => {

--- a/test/test.ts
+++ b/test/test.ts
@@ -1275,19 +1275,19 @@ test('is.domElement', t => {
 		assert.domElement({nodeType: 1, nodeName: 'div'});
 	});
 
-	const htmlTagNameToTypeName = {
-		div: 'HTMLDivElement',
-		input: 'HTMLInputElement',
-		span: 'HTMLSpanElement',
-		img: 'HTMLImageElement',
-		canvas: 'HTMLCanvasElement',
-		script: 'HTMLScriptElement'
-	};
+	const tagNames = [
+		'div',
+		'input',
+		'span',
+		'img',
+		'canvas',
+		'script'
+	];
 
-	for (const [tagName, typeName] of Object.entries(htmlTagNameToTypeName)) {
+	tagNames.forEach(tagName => {
 		const domElement = createDomElement(tagName);
-		t.is(is(domElement), typeName);
-	}
+		t.is(is(domElement), 'HTMLElement');
+	});
 });
 
 test('is.observable', t => {


### PR DESCRIPTION
This is the functional change that was removed from #113 

There was an unsafe cast in getObjectType which could allow any string to be returned. This was used as an output in the primary `is` function.

The primary function `is` now always returns a `TypeName`.

The other breaking change here is the return value of `HTMLElement` for dom elements like `div` or `span`. Previously it would return `HTMLDivElement` or `HTMLSpanElement`, but now they all return `HTMLElement`.
