### PR TITLE
Improve import for VS Code

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"email": "sindresorhus@gmail.com",
 		"url": "https://sindresorhus.com"
 	},
-	"main": "dist",
+	"main": "dist/index.js",
 	"engines": {
 		"node": ">=10"
 	},
@@ -64,7 +64,7 @@
 		"xo": "^0.26.1",
 		"zen-observable": "^0.8.8"
 	},
-	"types": "dist",
+	"types": "dist/index.d.ts",
 	"sideEffects": false,
 	"ava": {
 		"extensions": [


### PR DESCRIPTION
When 'main' & 'types' are pointing to 'dist' folder vscode will autoimport the package like this:
```ts
import is from '@sindresorhus/is/dist'
```