### PR TITLE
Fix assertion message for `.all` and `.any`

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -388,7 +388,7 @@ is.any = (predicate: Predicate | Predicate[], ...values: unknown[]): boolean => 
 
 is.all = (predicate: Predicate, ...values: unknown[]): boolean => predicateOnArray(Array.prototype.every, predicate, values);
 
-const assertType = (condition: boolean, description: string, value: unknown, options: { multipleValues?: boolean } = {}): asserts condition => {
+const assertType = (condition: boolean, description: string, value: unknown, options: {multipleValues?: boolean} = {}): asserts condition => {
 	if (!condition) {
 		const {multipleValues} = options;
 		const valuesMessage = multipleValues ?

--- a/source/index.ts
+++ b/source/index.ts
@@ -630,7 +630,6 @@ export const assert: Assert = {
 
 	// Variadic functions.
 	any: (predicate: Predicate | Predicate[], ...values: unknown[]): void | never => {
-		// Remove duplicate value types using Set.
 		return assertType(is.any(predicate, ...values), AssertionTypeDescription.any, values, {multipleValues: true});
 	},
 	all: (predicate: Predicate, ...values: unknown[]): void | never => assertType(is.all(predicate, ...values), AssertionTypeDescription.all, values, {multipleValues: true})

--- a/test/test.ts
+++ b/test/test.ts
@@ -1529,6 +1529,27 @@ test('is.any', t => {
 	t.throws(() => {
 		assert.any(is.string);
 	});
+
+	t.throws(() => {
+		assert.any(is.string, 1, 2, 3);
+	}, {
+		// Removes duplicates:
+		message: /received values of types `number`./
+	});
+
+	t.throws(() => {
+		assert.any(is.string, 1, [4]);
+	}, {
+		// Lists all types:
+		message: /received values of types `number`, `Array`./
+	});
+
+	t.throws(() => {
+		assert.any([is.string, is.nullOrUndefined], 1);
+	}, {
+		// Handles array as first argument:
+		message: /received values of types `number`./
+	});
 });
 
 test('is.all', t => {

--- a/test/test.ts
+++ b/test/test.ts
@@ -1591,6 +1591,20 @@ test('is.all', t => {
 	t.throws(() => {
 		assert.all(is.string);
 	});
+
+	t.throws(() => {
+		assert.all(is.string, 1, 2, 3);
+	}, {
+		// Removes duplicates:
+		message: /received values of types `number`./
+	});
+
+	t.throws(() => {
+		assert.all(is.string, 1, [4]);
+	}, {
+		// Lists all types:
+		message: /received values of types `number`, `Array`./
+	});
 });
 
 test('assert', t => {


### PR DESCRIPTION
This PR fixes #131 

Approach: Add an options object to `assertType`. This allows a custom failure message from the calling code. It's a function that returns a string and passed in as `getValuesMessage` to the options object.

What do you think of the approach?