### PR TITLE
Fix `is.iterable` and `is.asyncIterable` TypeScript types

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -181,11 +181,12 @@ is.buffer = (value: unknown): value is Buffer => (value as any)?.constructor?.is
 
 is.nullOrUndefined = (value: unknown): value is null | undefined => is.null_(value) || is.undefined(value);
 is.object = (value: unknown): value is object => !is.null_(value) && (typeof value === 'object' || is.function_(value));
-is.iterable = <T = unknown>(value: unknown): value is IterableIterator<T> => is.function_((value as IterableIterator<T>)?.[Symbol.iterator]);
 
+is.iterable = <T = unknown>(value: unknown): value is Iterable<T> => is.function_((value as Iterable<T>)?.[Symbol.iterator]);
+is.iterableIterator = <T = unknown>(value: unknown): value is IterableIterator<T> => is.iterable(value) && is.function_((value as IterableIterator<T>)?.next) && is.any([is.function_, is.undefined], (value as IterableIterator<T>)?.throw) && is.any([is.function_, is.undefined], (value as IterableIterator<T>)?.return);
 is.asyncIterable = <T = unknown>(value: unknown): value is AsyncIterableIterator<T> => is.function_((value as AsyncIterableIterator<T>)?.[Symbol.asyncIterator]);
 
-is.generator = (value: unknown): value is Generator => is.iterable(value) && is.function_(value.next) && is.function_(value.throw);
+is.generator = (value: unknown): value is Generator => is.iterable(value) && is.function_((value as Generator)?.next) && is.function_((value as Generator)?.throw);
 
 is.asyncGenerator = (value: unknown): value is AsyncGenerator => is.asyncIterable(value) && is.function_(value.next) && is.function_(value.throw);
 
@@ -413,6 +414,7 @@ export const enum AssertionTypeDescription {
 	numericString = 'string with a number',
 	nullOrUndefined = 'null or undefined',
 	iterable = 'Iterable',
+	iterableIterator = 'Iterable Iterator',
 	asyncIterable = 'AsyncIterable',
 	nativePromise = 'native Promise',
 	urlString = 'string with a URL',
@@ -469,6 +471,7 @@ interface Assert {
 	nullOrUndefined: (value: unknown) => asserts value is null | undefined;
 	object: <Key extends keyof any = string, Value = unknown>(value: unknown) => asserts value is Record<Key, Value>;
 	iterable: <T = unknown>(value: unknown) => asserts value is Iterable<T>;
+	iterableIterator: <T = unknown>(value: unknown) => asserts value is IterableIterator<T>;
 	asyncIterable: <T = unknown>(value: unknown) => asserts value is AsyncIterable<T>;
 	generator: (value: unknown) => asserts value is Generator;
 	asyncGenerator: (value: unknown) => asserts value is AsyncGenerator;
@@ -569,6 +572,7 @@ export const assert: Assert = {
 	nullOrUndefined: (value: unknown): asserts value is null | undefined => assertType(is.nullOrUndefined(value), AssertionTypeDescription.nullOrUndefined, value),
 	object: (value: unknown): asserts value is object => assertType(is.object(value), 'Object', value),
 	iterable: <T = unknown>(value: unknown): asserts value is Iterable<T> => assertType(is.iterable(value), AssertionTypeDescription.iterable, value),
+	iterableIterator: <T = unknown>(value: unknown): asserts value is IterableIterator<T> => assertType(is.iterableIterator(value), AssertionTypeDescription.iterableIterator, value),
 	asyncIterable: <T = unknown>(value: unknown): asserts value is AsyncIterable<T> => assertType(is.asyncIterable(value), AssertionTypeDescription.asyncIterable, value),
 	generator: (value: unknown): asserts value is Generator => assertType(is.generator(value), 'Generator', value),
 	asyncGenerator: (value: unknown): asserts value is AsyncGenerator => assertType(is.asyncGenerator(value), 'AsyncGenerator', value),

--- a/source/index.ts
+++ b/source/index.ts
@@ -181,14 +181,13 @@ is.buffer = (value: unknown): value is Buffer => (value as any)?.constructor?.is
 
 is.nullOrUndefined = (value: unknown): value is null | undefined => is.null_(value) || is.undefined(value);
 is.object = (value: unknown): value is object => !is.null_(value) && (typeof value === 'object' || is.function_(value));
-
 is.iterable = <T = unknown>(value: unknown): value is Iterable<T> => is.function_((value as Iterable<T>)?.[Symbol.iterator]);
-is.iterableIterator = <T = unknown>(value: unknown): value is IterableIterator<T> => is.iterable(value) && is.function_((value as IterableIterator<T>)?.next) && is.any([is.function_, is.undefined], (value as IterableIterator<T>)?.throw) && is.any([is.function_, is.undefined], (value as IterableIterator<T>)?.return);
-is.asyncIterable = <T = unknown>(value: unknown): value is AsyncIterableIterator<T> => is.function_((value as AsyncIterableIterator<T>)?.[Symbol.asyncIterator]);
+
+is.asyncIterable = <T = unknown>(value: unknown): value is AsyncIterable<T> => is.function_((value as AsyncIterable<T>)?.[Symbol.asyncIterator]);
 
 is.generator = (value: unknown): value is Generator => is.iterable(value) && is.function_((value as Generator)?.next) && is.function_((value as Generator)?.throw);
 
-is.asyncGenerator = (value: unknown): value is AsyncGenerator => is.asyncIterable(value) && is.function_(value.next) && is.function_(value.throw);
+is.asyncGenerator = (value: unknown): value is AsyncGenerator => is.asyncIterable(value) && is.function_((value as AsyncGenerator).next) && is.function_((value as AsyncGenerator).throw);
 
 is.nativePromise = <T = unknown>(value: unknown): value is Promise<T> =>
 	isObjectOfType<Promise<T>>('Promise')(value);
@@ -414,7 +413,6 @@ export const enum AssertionTypeDescription {
 	numericString = 'string with a number',
 	nullOrUndefined = 'null or undefined',
 	iterable = 'Iterable',
-	iterableIterator = 'Iterable Iterator',
 	asyncIterable = 'AsyncIterable',
 	nativePromise = 'native Promise',
 	urlString = 'string with a URL',
@@ -471,7 +469,6 @@ interface Assert {
 	nullOrUndefined: (value: unknown) => asserts value is null | undefined;
 	object: <Key extends keyof any = string, Value = unknown>(value: unknown) => asserts value is Record<Key, Value>;
 	iterable: <T = unknown>(value: unknown) => asserts value is Iterable<T>;
-	iterableIterator: <T = unknown>(value: unknown) => asserts value is IterableIterator<T>;
 	asyncIterable: <T = unknown>(value: unknown) => asserts value is AsyncIterable<T>;
 	generator: (value: unknown) => asserts value is Generator;
 	asyncGenerator: (value: unknown) => asserts value is AsyncGenerator;
@@ -572,7 +569,6 @@ export const assert: Assert = {
 	nullOrUndefined: (value: unknown): asserts value is null | undefined => assertType(is.nullOrUndefined(value), AssertionTypeDescription.nullOrUndefined, value),
 	object: (value: unknown): asserts value is object => assertType(is.object(value), 'Object', value),
 	iterable: <T = unknown>(value: unknown): asserts value is Iterable<T> => assertType(is.iterable(value), AssertionTypeDescription.iterable, value),
-	iterableIterator: <T = unknown>(value: unknown): asserts value is IterableIterator<T> => assertType(is.iterableIterator(value), AssertionTypeDescription.iterableIterator, value),
 	asyncIterable: <T = unknown>(value: unknown): asserts value is AsyncIterable<T> => assertType(is.asyncIterable(value), AssertionTypeDescription.asyncIterable, value),
 	generator: (value: unknown): asserts value is Generator => assertType(is.generator(value), 'Generator', value),
 	asyncGenerator: (value: unknown): asserts value is AsyncGenerator => assertType(is.asyncGenerator(value), 'AsyncGenerator', value),

--- a/test/test.ts
+++ b/test/test.ts
@@ -1069,6 +1069,66 @@ test('is.iterable', t => {
 	});
 });
 
+test('is.iterableIterator', t => {
+	t.true(is.iterableIterator({
+		[Symbol.iterator]: () => ({[Symbol.iterator]: () => {}}),
+		next: () => {},
+		throws: () => {},
+		returns: () => {}
+	}));
+	t.true(is.iterableIterator({
+		[Symbol.iterator]: () => ({[Symbol.iterator]: () => {}}),
+		next: () => {},
+		throws: undefined,
+		returns: undefined
+	}));
+	t.false(is.iterableIterator(new Map()));
+	t.false(is.iterableIterator([]));
+	t.false(is.iterableIterator(''));
+	t.false(is.iterableIterator(null));
+	t.false(is.iterableIterator(undefined));
+	t.false(is.iterableIterator(0));
+	t.false(is.iterableIterator(NaN));
+	t.false(is.iterableIterator(Infinity));
+	t.false(is.iterableIterator({}));
+
+	t.notThrows(() => {
+		assert.iterableIterator({
+			[Symbol.iterator]: () => ({[Symbol.iterator]: () => {}}),
+			next: () => {},
+			throws: () => {},
+			returns: () => {}
+		});
+	});
+	t.throws(() => {
+		assert.iterableIterator('');
+	});
+	t.throws(() => {
+		assert.iterableIterator([]);
+	});
+	t.throws(() => {
+		assert.iterableIterator(new Map());
+	});
+	t.throws(() => {
+		assert.iterableIterator(null);
+	});
+	t.throws(() => {
+		assert.iterableIterator(undefined);
+	});
+	t.throws(() => {
+		assert.iterableIterator(0);
+	});
+	t.throws(() => {
+		assert.iterableIterator(NaN);
+	});
+	t.throws(() => {
+		assert.iterableIterator(Infinity);
+	});
+	t.throws(() => {
+		assert.iterableIterator({});
+	});
+});
+
 test('is.asyncIterable', t => {
 	t.true(is.asyncIterable({
 		[Symbol.asyncIterator]: () => {}

--- a/test/test.ts
+++ b/test/test.ts
@@ -1069,66 +1069,6 @@ test('is.iterable', t => {
 	});
 });
 
-test('is.iterableIterator', t => {
-	t.true(is.iterableIterator({
-		[Symbol.iterator]: () => ({[Symbol.iterator]: () => {}}),
-		next: () => {},
-		throws: () => {},
-		returns: () => {}
-	}));
-	t.true(is.iterableIterator({
-		[Symbol.iterator]: () => ({[Symbol.iterator]: () => {}}),
-		next: () => {},
-		throws: undefined,
-		returns: undefined
-	}));
-	t.false(is.iterableIterator(new Map()));
-	t.false(is.iterableIterator([]));
-	t.false(is.iterableIterator(''));
-	t.false(is.iterableIterator(null));
-	t.false(is.iterableIterator(undefined));
-	t.false(is.iterableIterator(0));
-	t.false(is.iterableIterator(NaN));
-	t.false(is.iterableIterator(Infinity));
-	t.false(is.iterableIterator({}));
-
-	t.notThrows(() => {
-		assert.iterableIterator({
-			[Symbol.iterator]: () => ({[Symbol.iterator]: () => {}}),
-			next: () => {},
-			throws: () => {},
-			returns: () => {}
-		});
-	});
-	t.throws(() => {
-		assert.iterableIterator('');
-	});
-	t.throws(() => {
-		assert.iterableIterator([]);
-	});
-	t.throws(() => {
-		assert.iterableIterator(new Map());
-	});
-	t.throws(() => {
-		assert.iterableIterator(null);
-	});
-	t.throws(() => {
-		assert.iterableIterator(undefined);
-	});
-	t.throws(() => {
-		assert.iterableIterator(0);
-	});
-	t.throws(() => {
-		assert.iterableIterator(NaN);
-	});
-	t.throws(() => {
-		assert.iterableIterator(Infinity);
-	});
-	t.throws(() => {
-		assert.iterableIterator({});
-	});
-});
-
 test('is.asyncIterable', t => {
 	t.true(is.asyncIterable({
 		[Symbol.asyncIterator]: () => {}


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/is/issues/128

Also added `is.iterableIterator`.