### PR TITLE
Add `is.enumCase` and `assert.enumCase`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -213,13 +213,13 @@ is.boundFunction(function () {});
 ##### .dataView(value)
 
 ##### .enumCase(value, enum)
-
+**TypeScript-only**
 Returns `true` if `value` is a member of `enum`.
 
 ```ts
-enum EnumDirection {
-	Asc = 'asc',
-	Desc = 'desc'
+enum Direction {
+	Ascending = 'ascending',
+	Descending = 'descending'
 }
 
 is.enumCase('asc', EnumDirection);

--- a/readme.md
+++ b/readme.md
@@ -212,6 +212,23 @@ is.boundFunction(function () {});
 ##### .sharedArrayBuffer(value)
 ##### .dataView(value)
 
+##### .enumCase(value, enum)
+
+Returns `true` if `value` is a member of `enum`.
+
+```ts
+enum EnumDirection {
+	Asc = 'asc',
+	Desc = 'desc'
+}
+
+is.enumCase('asc', EnumDirection);
+//=> true
+
+is.enumCase('other', EnumDirection);
+//=> false
+```
+
 #### Emptiness
 
 ##### .emptyString(value)

--- a/readme.md
+++ b/readme.md
@@ -213,7 +213,9 @@ is.boundFunction(function () {});
 ##### .dataView(value)
 
 ##### .enumCase(value, enum)
+
 **TypeScript-only**
+
 Returns `true` if `value` is a member of `enum`.
 
 ```ts
@@ -222,10 +224,10 @@ enum Direction {
 	Descending = 'descending'
 }
 
-is.enumCase('asc', EnumDirection);
+is.enumCase('ascending', Direction);
 //=> true
 
-is.enumCase('other', EnumDirection);
+is.enumCase('other', Direction);
 //=> false
 ```
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -230,6 +230,7 @@ is.bigUint64Array = isObjectOfType<BigUint64Array>('BigUint64Array');
 is.arrayBuffer = isObjectOfType<ArrayBuffer>('ArrayBuffer');
 is.sharedArrayBuffer = isObjectOfType<SharedArrayBuffer>('SharedArrayBuffer');
 is.dataView = isObjectOfType<DataView>('DataView');
+is.enumCase = <T = unknown>(value: unknown, targetEnum: T) => Object.values(targetEnum).includes(value as string);
 
 is.directInstanceOf = <T>(instance: unknown, class_: Class<T>): instance is T => Object.getPrototypeOf(instance) === class_.prototype;
 is.urlInstance = (value: unknown): value is URL => isObjectOfType<URL>('URL')(value);
@@ -501,6 +502,7 @@ interface Assert {
 	arrayBuffer: (value: unknown) => asserts value is ArrayBuffer;
 	sharedArrayBuffer: (value: unknown) => asserts value is SharedArrayBuffer;
 	dataView: (value: unknown) => asserts value is DataView;
+	enumCase: <T = unknown>(value: unknown, targetEnum: T) => asserts value is T[keyof T];
 	urlInstance: (value: unknown) => asserts value is URL;
 	urlString: (value: unknown) => asserts value is string;
 	truthy: (value: unknown) => asserts value is unknown;
@@ -601,6 +603,7 @@ export const assert: Assert = {
 	arrayBuffer: (value: unknown): asserts value is ArrayBuffer => assertType(is.arrayBuffer(value), 'ArrayBuffer', value),
 	sharedArrayBuffer: (value: unknown): asserts value is SharedArrayBuffer => assertType(is.sharedArrayBuffer(value), 'SharedArrayBuffer', value),
 	dataView: (value: unknown): asserts value is DataView => assertType(is.dataView(value), 'DataView', value),
+	enumCase: <T = unknown>(value: unknown, targetEnum: T): asserts value is T[keyof T] => assertType(is.enumCase(value, targetEnum), 'EnumCase', value),
 	urlInstance: (value: unknown): asserts value is URL => assertType(is.urlInstance(value), 'URL', value),
 	urlString: (value: unknown): asserts value is string => assertType(is.urlString(value), AssertionTypeDescription.urlString, value),
 	truthy: (value: unknown): asserts value is unknown => assertType(is.truthy(value), AssertionTypeDescription.truthy, value),

--- a/test/test.ts
+++ b/test/test.ts
@@ -832,6 +832,23 @@ test('is.dataView', t => {
 	testType(t, 'dataView');
 });
 
+test('is.enumCase', t => {
+	enum NonNumericalEnum {
+		Key1 = 'key1',
+		Key2 = 'key2',
+	}
+
+	t.true(is.enumCase('key1', NonNumericalEnum));
+	t.notThrows(() => {
+		assert.enumCase('key1', NonNumericalEnum);
+	});
+
+	t.false(is.enumCase('invalid', NonNumericalEnum));
+	t.throws(() => {
+		assert.enumCase('invalid', NonNumericalEnum);
+	});
+});
+
 test('is.directInstanceOf', t => {
 	const error = new Error();
 	const errorSubclass = new ErrorSubclassFixture();


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/is/issues/148

Turns out typing this correctly was a bit trickier than I initially expected, since enums are both a value and a type.

Given this:

```ts
enum Direction {
	Asc = 'asc',
	Desc = 'desc'
}
const input: string = 'asc';
assert.enumCase(input, Direction);
```

If `assert.enumCase` was typed to return `asserts value is T` (T being the inferred type of `Direction`), the asserted type of `input` would become `string & typeof Direction`, which is no good.

Typing it as `asserts value is T[keyof T]` instead did the trick, making `input` be typed as `Direction`.