### PR TITLE
Add type guard for `is.truthy` and `is.falsy`

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -250,7 +250,7 @@ is.urlString = (value: unknown): value is string => {
 // Example: `is.truthy = (value: unknown): value is (not false | not 0 | not '' | not undefined | not null) => Boolean(value);`
 is.truthy = <T>(value: T | Falsy): value is T => Boolean(value);
 // Example: `is.falsy = (value: unknown): value is (not true | 0 | '' | undefined | null) => Boolean(value);`
-is.falsy = (value: unknown) => !value;
+is.falsy = <T>(value: T | Falsy): value is Falsy => !value;
 
 is.nan = (value: unknown) => Number.isNaN(value as number);
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -2,7 +2,7 @@
 /// <reference lib="dom"/>
 /// <reference types="node"/>
 
-import {Class, TypedArray, ObservableLike, Primitive} from './types';
+import {Class, Falsy, TypedArray, ObservableLike, Primitive} from './types';
 
 const typedArrayTypeNames = [
 	'Int8Array',
@@ -247,9 +247,8 @@ is.urlString = (value: unknown): value is string => {
 	}
 };
 
-// TODO: Use the `not` operator with a type guard here when it's available.
 // Example: `is.truthy = (value: unknown): value is (not false | not 0 | not '' | not undefined | not null) => Boolean(value);`
-is.truthy = (value: unknown) => Boolean(value);
+is.truthy = <T>(value: T | Falsy): value is T => Boolean(value);
 // Example: `is.falsy = (value: unknown): value is (not true | 0 | '' | undefined | null) => Boolean(value);`
 is.falsy = (value: unknown) => !value;
 

--- a/source/types.ts
+++ b/source/types.ts
@@ -47,3 +47,5 @@ export interface ObservableLike {
 	subscribe(observer: (value: unknown) => void): void;
 	[Symbol.observable](): ObservableLike;
 }
+
+export type Falsy = false | 0 | 0n | '' | null | undefined;


### PR DESCRIPTION
Fixes #146 and not sure if adding the same Falsy guard to `is.falsy` helps there because I'm just using `is.truthy` as a `.filter` but happy to add the `Falsy` annotation to `is.falsy` too if helpful