### PR TITLE
Improve `is.integer`, `is.safeInteger`, `is.infinite` TypeScript type

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 		"rxjs": "^6.4.0",
 		"tempy": "^0.4.0",
 		"ts-node": "^8.3.0",
-		"typescript": "~3.8.2",
+		"typescript": "~4.1.2",
 		"xo": "^0.26.1",
 		"zen-observable": "^0.8.8"
 	},

--- a/source/index.ts
+++ b/source/index.ts
@@ -2,7 +2,7 @@
 /// <reference lib="dom"/>
 /// <reference types="node"/>
 
-import {Class, TypedArray, ObservableLike, Primitive} from './types';
+import {Class, TypedArray, ObservableLike, Primitive, Integer} from './types';
 
 const typedArrayTypeNames = [
 	'Int8Array',
@@ -258,8 +258,8 @@ is.nan = (value: unknown) => Number.isNaN(value as number);
 
 is.primitive = (value: unknown): value is Primitive => is.null_(value) || isPrimitiveTypeName(typeof value);
 
-is.integer = (value: unknown): value is number => Number.isInteger(value as number);
-is.safeInteger = (value: unknown): value is number => Number.isSafeInteger(value as number);
+is.integer = <T extends number>(value: T): value is Integer<T> => Number.isInteger(value);
+is.safeInteger = <T extends number>(value: T): value is Integer<T> => Number.isSafeInteger(value);
 
 is.plainObject = <Value = unknown>(value: unknown): value is Record<PropertyKey, Value> => {
 	// From: https://github.com/sindresorhus/is-plain-obj/blob/main/index.js
@@ -279,7 +279,7 @@ export interface ArrayLike<T> {
 	readonly length: number;
 }
 
-const isValidLength = (value: unknown): value is number => is.safeInteger(value) && value >= 0;
+const isValidLength = <T extends number>(value: T): value is Integer<T> => is.safeInteger(value) && value >= 0;
 is.arrayLike = <T = unknown>(value: unknown): value is ArrayLike<T> => !is.nullOrUndefined(value) && !is.function_(value) && isValidLength((value as ArrayLike<T>).length);
 
 is.inRange = (value: number, range: number | number[]): value is number => {
@@ -336,7 +336,7 @@ is.nodeStream = (value: unknown): value is NodeStream => is.object(value) && is.
 
 is.infinite = (value: unknown): value is number => value === Infinity || value === -Infinity;
 
-const isAbsoluteMod2 = (remainder: number) => (value: number): value is number => is.integer(value) && Math.abs(value % 2) === remainder;
+const isAbsoluteMod2 = (remainder: number) => <T extends number>(value: T): value is Integer<T> => is.integer(value) && Math.abs(value % 2) === remainder;
 is.evenInteger = isAbsoluteMod2(0);
 is.oddInteger = isAbsoluteMod2(1);
 
@@ -509,8 +509,8 @@ interface Assert {
 	falsy: (value: unknown) => asserts value is unknown;
 	nan: (value: unknown) => asserts value is unknown;
 	primitive: (value: unknown) => asserts value is Primitive;
-	integer: (value: unknown) => asserts value is number;
-	safeInteger: (value: unknown) => asserts value is number;
+	integer: <T extends number>(value: T) => asserts value is Integer<T>;
+	safeInteger: <T extends number>(value: T) => asserts value is Integer<T>;
 	plainObject: <Value = unknown>(value: unknown) => asserts value is Record<PropertyKey, Value>;
 	typedArray: (value: unknown) => asserts value is TypedArray;
 	arrayLike: <T = unknown>(value: unknown) => asserts value is ArrayLike<T>;
@@ -534,8 +534,8 @@ interface Assert {
 	urlSearchParams: (value: unknown) => asserts value is URLSearchParams;
 
 	// Numbers.
-	evenInteger: (value: number) => asserts value is number;
-	oddInteger: (value: number) => asserts value is number;
+	evenInteger: <T extends number>(value: T) => asserts value is Integer<T>;
+	oddInteger: <T extends number>(value: T) => asserts value is Integer<T>;
 
 	// Two arguments.
 	directInstanceOf: <T>(instance: unknown, class_: Class<T>) => asserts instance is T;
@@ -610,8 +610,8 @@ export const assert: Assert = {
 	falsy: (value: unknown): asserts value is unknown => assertType(is.falsy(value), AssertionTypeDescription.falsy, value),
 	nan: (value: unknown): asserts value is unknown => assertType(is.nan(value), AssertionTypeDescription.nan, value),
 	primitive: (value: unknown): asserts value is Primitive => assertType(is.primitive(value), AssertionTypeDescription.primitive, value),
-	integer: (value: unknown): asserts value is number => assertType(is.integer(value), AssertionTypeDescription.integer, value),
-	safeInteger: (value: unknown): asserts value is number => assertType(is.safeInteger(value), AssertionTypeDescription.safeInteger, value),
+	integer: <T extends number>(value: T): asserts value is Integer<T> => assertType(is.integer(value), AssertionTypeDescription.integer, value),
+	safeInteger: <T extends number>(value: T): asserts value is Integer<T> => assertType(is.safeInteger(value), AssertionTypeDescription.safeInteger, value),
 	plainObject: <Value = unknown>(value: unknown): asserts value is Record<PropertyKey, Value> => assertType(is.plainObject(value), AssertionTypeDescription.plainObject, value),
 	typedArray: (value: unknown): asserts value is TypedArray => assertType(is.typedArray(value), AssertionTypeDescription.typedArray, value),
 	arrayLike: <T = unknown>(value: unknown): asserts value is ArrayLike<T> => assertType(is.arrayLike(value), AssertionTypeDescription.arrayLike, value),
@@ -635,8 +635,8 @@ export const assert: Assert = {
 	urlSearchParams: (value: unknown): asserts value is URLSearchParams => assertType(is.urlSearchParams(value), 'URLSearchParams', value),
 
 	// Numbers.
-	evenInteger: (value: number): asserts value is number => assertType(is.evenInteger(value), AssertionTypeDescription.evenInteger, value),
-	oddInteger: (value: number): asserts value is number => assertType(is.oddInteger(value), AssertionTypeDescription.oddInteger, value),
+	evenInteger: <T extends number>(value: T): asserts value is Integer<T> => assertType(is.evenInteger(value), AssertionTypeDescription.evenInteger, value),
+	oddInteger: <T extends number>(value: T): asserts value is Integer<T> => assertType(is.oddInteger(value), AssertionTypeDescription.oddInteger, value),
 
 	// Two arguments.
 	directInstanceOf: <T>(instance: unknown, class_: Class<T>): asserts instance is T => assertType(is.directInstanceOf(instance, class_), AssertionTypeDescription.directInstanceOf, instance),

--- a/source/index.ts
+++ b/source/index.ts
@@ -2,7 +2,7 @@
 /// <reference lib="dom"/>
 /// <reference types="node"/>
 
-import {Class, TypedArray, ObservableLike, Primitive, Integer} from './types';
+import {Class, TypedArray, ObservableLike, Primitive, Integer, PositiveInfinity, NegativeInfinity} from './types';
 
 const typedArrayTypeNames = [
 	'Int8Array',
@@ -334,7 +334,7 @@ export interface NodeStream extends NodeJS.EventEmitter {
 
 is.nodeStream = (value: unknown): value is NodeStream => is.object(value) && is.function_((value as NodeStream).pipe) && !is.observable(value);
 
-is.infinite = (value: unknown): value is number => value === Infinity || value === -Infinity;
+is.infinite = (value: unknown): value is NegativeInfinity | PositiveInfinity => value === Infinity || value === -Infinity;
 
 const isAbsoluteMod2 = (remainder: number) => <T extends number>(value: T): value is Integer<T> => is.integer(value) && Math.abs(value % 2) === remainder;
 is.evenInteger = isAbsoluteMod2(0);
@@ -517,7 +517,7 @@ interface Assert {
 	domElement: (value: unknown) => asserts value is HTMLElement;
 	observable: (value: unknown) => asserts value is ObservableLike;
 	nodeStream: (value: unknown) => asserts value is NodeStream;
-	infinite: (value: unknown) => asserts value is number;
+	infinite: (value: unknown) => asserts value is NegativeInfinity | PositiveInfinity;
 	emptyArray: (value: unknown) => asserts value is never[];
 	nonEmptyArray: (value: unknown) => asserts value is unknown[];
 	emptyString: (value: unknown) => asserts value is '';
@@ -618,7 +618,7 @@ export const assert: Assert = {
 	domElement: (value: unknown): asserts value is HTMLElement => assertType(is.domElement(value), AssertionTypeDescription.domElement, value),
 	observable: (value: unknown): asserts value is ObservableLike => assertType(is.observable(value), 'Observable', value),
 	nodeStream: (value: unknown): asserts value is NodeStream => assertType(is.nodeStream(value), AssertionTypeDescription.nodeStream, value),
-	infinite: (value: unknown): asserts value is number => assertType(is.infinite(value), AssertionTypeDescription.infinite, value),
+	infinite: (value: unknown): asserts value is NegativeInfinity | PositiveInfinity => assertType(is.infinite(value), AssertionTypeDescription.infinite, value),
 	emptyArray: (value: unknown): asserts value is never[] => assertType(is.emptyArray(value), AssertionTypeDescription.emptyArray, value),
 	nonEmptyArray: (value: unknown): asserts value is unknown[] => assertType(is.nonEmptyArray(value), AssertionTypeDescription.nonEmptyArray, value),
 	emptyString: (value: unknown): asserts value is '' => assertType(is.emptyString(value), AssertionTypeDescription.emptyString, value),

--- a/source/types.ts
+++ b/source/types.ts
@@ -68,3 +68,21 @@ declare function setYear<T extends number>(length: Integer<T>): void;
 // `${bigint}` is a type that matches a valid bigint literal without the `n` (ex. 1, 0b1, 0o1, 0x1)
 // Because T is a number and not a string we can effectively use this to filter out any numbers containing decimal points
 export type Integer<Type extends number> = `${Type}` extends `${bigint}` ? Type : never;
+
+/**
+Matches the hidden `Infinity` type.
+Please upvote [this issue](https://github.com/microsoft/TypeScript/issues/32277) if you want to have this type as a built-in in TypeScript.
+@see NegativeInfinity
+@category Numeric
+*/
+// See https://github.com/microsoft/TypeScript/issues/31752
+export type PositiveInfinity = 1e999;
+
+/**
+Matches the hidden `-Infinity` type.
+Please upvote [this issue](https://github.com/microsoft/TypeScript/issues/32277) if you want to have this type as a built-in in TypeScript.
+@see PositiveInfinity
+@category Numeric
+*/
+// See https://github.com/microsoft/TypeScript/issues/31752
+export type NegativeInfinity = -1e999;

--- a/source/types.ts
+++ b/source/types.ts
@@ -47,3 +47,24 @@ export interface ObservableLike {
 	subscribe(observer: (value: unknown) => void): void;
 	[Symbol.observable](): ObservableLike;
 }
+
+/**
+A `number` that is an integer.
+You can't pass a `bigint` as they are already guaranteed to be integers.
+
+Use-case: Validating and documenting parameters.
+
+@example
+```
+import {Integer} from 'type-fest';
+declare function setYear<T extends number>(length: Integer<T>): void;
+```
+
+@see NegativeInteger
+@see NonNegativeInteger
+
+@category Numeric
+*/
+// `${bigint}` is a type that matches a valid bigint literal without the `n` (ex. 1, 0b1, 0o1, 0x1)
+// Because T is a number and not a string we can effectively use this to filter out any numbers containing decimal points
+export type Integer<Type extends number> = `${Type}` extends `${bigint}` ? Type : never;


### PR DESCRIPTION
- It requires `typescript@4.1.2`, since `Integer` type in `type-fest` is using [template literal type](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-1.html#template-literal-types)
- Parameter types of `is.integer` and `is.safeInteger` are narrowed to number, because `Integer` type extends number type.
	- It has side effect to `is.evenInteger`, `is.oddInteger`, and also test cases in `is.any` are broken.
	- It could be resolved by making `Integer` type extends unknown.

```ts
export type Integer<Type> = Type extends number ?
	`${Type}` extends `${bigint}`
		? Type
		: never
	: never;
```

resolve #147 