### PR TITLE
Fix `NaN` detection in `.is()`

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -50,6 +50,7 @@ const objectTypeNames = [
 	'FormData',
 	'URLSearchParams',
 	'HTMLElement',
+	'NaN',
 	...typedArrayTypeNames
 ] as const;
 
@@ -110,7 +111,7 @@ function is(value: unknown): TypeName {
 		case 'string':
 			return 'string';
 		case 'number':
-			return 'number';
+			return Number.isNaN(value) ? 'NaN' : 'number';
 		case 'boolean':
 			return 'boolean';
 		case 'function':

--- a/test/test.ts
+++ b/test/test.ts
@@ -446,7 +446,7 @@ const types = new Map<string, Test>([
 			NaN,
 			Number.NaN
 		],
-		typename: 'number',
+		typename: 'NaN',
 		typeDescription: AssertionTypeDescription.nan
 	}],
 	['nullOrUndefined', {


### PR DESCRIPTION
`NaN` is not a number, this fixes the is() return for it.

before
```js
is(NaN) // => 'number'
```

after
```js
is(NaN) // => 'NaN'
```

---

Fixes #160