### PR TITLE
fix: revert exports syntax change

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,8 @@
 		"url": "https://sindresorhus.com"
 	},
 	"type": "module",
-	"exports": {
-		"types": "./dist/index.d.ts",
-		"default": "./dist/index.js"
-	},
+	"exports": "./dist/index.js",
+	"types": "./dist/index.d.ts",
 	"engines": {
 		"node": ">=14.16"
 	},


### PR DESCRIPTION
Resolves #179 

The exports syntax that was used in v5.4.0 only works in node v20+

Reverting it back to the previous syntax fixes the problem, but I tried to test it with node v20 and ran into an error:

```
npx ts-node-esm ./index.ts
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for /Users/bjornstar/test/index.ts
```

This seems to be an issue with ts-node in node v20 - https://github.com/TypeStrong/ts-node/issues/1997
With a WIP PR from isaacs - https://github.com/TypeStrong/ts-node/pull/2009

In the meantime there is a workaround to use the ts-node/esm loader directly:

```
node --no-warnings=ExperimentalWarning --loader ts-node/esm ./index.ts
```

It would be nice if we could unblock existing node v16 / v18 users until `ts-node` is fixed on node v20.
