### PR TITLE
Add node v20 to the node version matrix in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 20
           - 18
           - 16
           - 14

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 	},
 	"scripts": {
 		"build": "del dist && tsc",
-		"test": "tsc --noEmit && xo && ava",
+		"test": "tsc --noEmit && xo && NODE_OPTIONS='--loader=ts-node/esm --no-warnings=ExperimentalWarning' ava",
 		"prepare": "npm run build"
 	},
 	"files": [
@@ -69,9 +69,6 @@
 	"ava": {
 		"extensions": {
 			"ts": "module"
-		},
-		"nodeArguments": [
-			"--loader=ts-node/esm"
-		]
+		}
 	}
 }


### PR DESCRIPTION
Since it's the latest stable version of node, we should include it in our tests.
