### PR TITLE
Drop node v14 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,6 @@ jobs:
         node-version:
           - 18
           - 16
-          - 14
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"default": "./dist/index.js"
 	},
 	"engines": {
-		"node": ">=14.16"
+		"node": ">=16"
 	},
 	"scripts": {
 		"build": "del dist && tsc",


### PR DESCRIPTION
Official support for v14 has [reached end of life at the end of April 2023](https://github.com/nodejs/Release).

We can set node v16 as the minimum version and stop testing on node v14.
