### PR TITLE
Fix type narrowing for `nonEmptyArray`

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -384,7 +384,7 @@ is.oddInteger = isAbsoluteMod2(1);
 
 is.emptyArray = (value: unknown): value is never[] => is.array(value) && value.length === 0;
 
-is.nonEmptyArray = (value: unknown): value is [unknown, ...unknown[]] => is.array(value) && value.length > 0;
+is.nonEmptyArray = <T = unknown>(value: T | T[]): value is [T, ...T[]] => is.array(value) && value.length > 0;
 
 is.emptyString = (value: unknown): value is '' => is.string(value) && value.length === 0;
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -384,7 +384,7 @@ is.oddInteger = isAbsoluteMod2(1);
 
 is.emptyArray = (value: unknown): value is never[] => is.array(value) && value.length === 0;
 
-is.nonEmptyArray = <T = unknown, Item = unknown>(value: T | Item[]): value is (T extends Item[] ? [Item, ...Item[]] : never) => is.array(value) && value.length > 0;
+is.nonEmptyArray = <T = unknown, Item = unknown>(value: T | Item[]): value is (T extends Item[] ? [Item, ...Item[]] : T) => is.array(value) && value.length > 0;
 
 is.emptyString = (value: unknown): value is '' => is.string(value) && value.length === 0;
 
@@ -575,7 +575,7 @@ type Assert = {
 	nodeStream: (value: unknown) => asserts value is NodeStream;
 	infinite: (value: unknown) => asserts value is number;
 	emptyArray: (value: unknown) => asserts value is never[];
-	nonEmptyArray: <T = unknown, Item = unknown>(value: T | Item[]) => asserts value is (T extends Item[] ? [Item, ...Item[]] : never);
+	nonEmptyArray: <T = unknown, Item = unknown>(value: T | Item[]) => asserts value is (T extends Item[] ? [Item, ...Item[]] : T);
 	emptyString: (value: unknown) => asserts value is '';
 	emptyStringOrWhitespace: (value: unknown) => asserts value is string;
 	nonEmptyString: (value: unknown) => asserts value is string;
@@ -681,7 +681,7 @@ export const assert: Assert = {
 	nodeStream: (value: unknown): asserts value is NodeStream => assertType(is.nodeStream(value), AssertionTypeDescription.nodeStream, value),
 	infinite: (value: unknown): asserts value is number => assertType(is.infinite(value), AssertionTypeDescription.infinite, value),
 	emptyArray: (value: unknown): asserts value is never[] => assertType(is.emptyArray(value), AssertionTypeDescription.emptyArray, value),
-	nonEmptyArray: <T = unknown, Item = unknown>(value: T | Item[]): asserts value is (T extends Item[] ? [Item, ...Item[]] : never) => assertType(is.nonEmptyArray(value), AssertionTypeDescription.nonEmptyArray, value),
+	nonEmptyArray: <T = unknown, Item = unknown>(value: T | Item[]): asserts value is (T extends Item[] ? [Item, ...Item[]] : T) => assertType(is.nonEmptyArray(value), AssertionTypeDescription.nonEmptyArray, value),
 	emptyString: (value: unknown): asserts value is '' => assertType(is.emptyString(value), AssertionTypeDescription.emptyString, value),
 	emptyStringOrWhitespace: (value: unknown): asserts value is string => assertType(is.emptyStringOrWhitespace(value), AssertionTypeDescription.emptyStringOrWhitespace, value),
 	nonEmptyString: (value: unknown): asserts value is string => assertType(is.nonEmptyString(value), AssertionTypeDescription.nonEmptyString, value),

--- a/source/index.ts
+++ b/source/index.ts
@@ -575,7 +575,7 @@ type Assert = {
 	nodeStream: (value: unknown) => asserts value is NodeStream;
 	infinite: (value: unknown) => asserts value is number;
 	emptyArray: (value: unknown) => asserts value is never[];
-	nonEmptyArray: (value: unknown) => asserts value is [unknown, ...unknown[]];
+	nonEmptyArray: <T = unknown>(value: T | T[]) => asserts value is [T, ...T[]];
 	emptyString: (value: unknown) => asserts value is '';
 	emptyStringOrWhitespace: (value: unknown) => asserts value is string;
 	nonEmptyString: (value: unknown) => asserts value is string;
@@ -681,7 +681,7 @@ export const assert: Assert = {
 	nodeStream: (value: unknown): asserts value is NodeStream => assertType(is.nodeStream(value), AssertionTypeDescription.nodeStream, value),
 	infinite: (value: unknown): asserts value is number => assertType(is.infinite(value), AssertionTypeDescription.infinite, value),
 	emptyArray: (value: unknown): asserts value is never[] => assertType(is.emptyArray(value), AssertionTypeDescription.emptyArray, value),
-	nonEmptyArray: (value: unknown): asserts value is [unknown, ...unknown[]] => assertType(is.nonEmptyArray(value), AssertionTypeDescription.nonEmptyArray, value),
+	nonEmptyArray: <T = unknown>(value: T | T[]): asserts value is [T, ...T[]] => assertType(is.nonEmptyArray(value), AssertionTypeDescription.nonEmptyArray, value),
 	emptyString: (value: unknown): asserts value is '' => assertType(is.emptyString(value), AssertionTypeDescription.emptyString, value),
 	emptyStringOrWhitespace: (value: unknown): asserts value is string => assertType(is.emptyStringOrWhitespace(value), AssertionTypeDescription.emptyStringOrWhitespace, value),
 	nonEmptyString: (value: unknown): asserts value is string => assertType(is.nonEmptyString(value), AssertionTypeDescription.nonEmptyString, value),

--- a/source/index.ts
+++ b/source/index.ts
@@ -384,7 +384,7 @@ is.oddInteger = isAbsoluteMod2(1);
 
 is.emptyArray = (value: unknown): value is never[] => is.array(value) && value.length === 0;
 
-is.nonEmptyArray = <T = unknown>(value: T | T[]): value is [T, ...T[]] => is.array(value) && value.length > 0;
+is.nonEmptyArray = <T = unknown, Item = unknown>(value: T | Item[]): value is (T extends Item[] ? [Item, ...Item[]] : never) => is.array(value) && value.length > 0;
 
 is.emptyString = (value: unknown): value is '' => is.string(value) && value.length === 0;
 
@@ -575,7 +575,7 @@ type Assert = {
 	nodeStream: (value: unknown) => asserts value is NodeStream;
 	infinite: (value: unknown) => asserts value is number;
 	emptyArray: (value: unknown) => asserts value is never[];
-	nonEmptyArray: <T = unknown>(value: T | T[]) => asserts value is [T, ...T[]];
+	nonEmptyArray: <T = unknown, Item = unknown>(value: T | Item[]) => asserts value is (T extends Item[] ? [Item, ...Item[]] : never);
 	emptyString: (value: unknown) => asserts value is '';
 	emptyStringOrWhitespace: (value: unknown) => asserts value is string;
 	nonEmptyString: (value: unknown) => asserts value is string;
@@ -681,7 +681,7 @@ export const assert: Assert = {
 	nodeStream: (value: unknown): asserts value is NodeStream => assertType(is.nodeStream(value), AssertionTypeDescription.nodeStream, value),
 	infinite: (value: unknown): asserts value is number => assertType(is.infinite(value), AssertionTypeDescription.infinite, value),
 	emptyArray: (value: unknown): asserts value is never[] => assertType(is.emptyArray(value), AssertionTypeDescription.emptyArray, value),
-	nonEmptyArray: <T = unknown>(value: T | T[]): asserts value is [T, ...T[]] => assertType(is.nonEmptyArray(value), AssertionTypeDescription.nonEmptyArray, value),
+	nonEmptyArray: <T = unknown, Item = unknown>(value: T | Item[]): asserts value is (T extends Item[] ? [Item, ...Item[]] : never) => assertType(is.nonEmptyArray(value), AssertionTypeDescription.nonEmptyArray, value),
 	emptyString: (value: unknown): asserts value is '' => assertType(is.emptyString(value), AssertionTypeDescription.emptyString, value),
 	emptyStringOrWhitespace: (value: unknown): asserts value is string => assertType(is.emptyStringOrWhitespace(value), AssertionTypeDescription.emptyStringOrWhitespace, value),
 	nonEmptyString: (value: unknown): asserts value is string => assertType(is.nonEmptyString(value), AssertionTypeDescription.nonEmptyString, value),

--- a/test/test.ts
+++ b/test/test.ts
@@ -1448,16 +1448,35 @@ test('is.nonEmptyArray', t => {
 		assert.nonEmptyArray(new Array()); // eslint-disable-line @typescript-eslint/no-array-constructor
 	});
 
-	// https://github.com/sindresorhus/is/issues/174
-	// {
-	// 	const strings = ['foo', 'bar']
-	// 	const function_ = (value: string) => value;
+	{
+		const strings = ['🦄', 'unicorn'];
+		const function_ = (value: string) => value;
 
-	// 	if (is.nonEmptyArray(strings)) {
-	// 		const value = strings[0]
-	// 		function_(value);
-	// 	}
-	// }
+		if (is.nonEmptyArray(strings)) {
+			const value = strings[0];
+			function_(value);
+		}
+	}
+
+	{
+		const mixed = ['🦄', 'unicorn', 1, 2];
+		const function_ = (value: string | number) => value;
+
+		if (is.nonEmptyArray(mixed)) {
+			const value = mixed[0];
+			function_(value);
+		}
+	}
+
+	{
+		const arrays = [['🦄'], ['unicorn']];
+		const function_ = (value: string[]) => value;
+
+		if (is.nonEmptyArray(arrays)) {
+			const value = arrays[0];
+			function_(value);
+		}
+	}
 });
 
 test('is.emptyString', t => {

--- a/test/test.ts
+++ b/test/test.ts
@@ -1477,6 +1477,36 @@ test('is.nonEmptyArray', t => {
 			function_(value);
 		}
 	}
+
+	{
+		const strings = ['🦄', 'unicorn'];
+		const function_ = (value: string) => value;
+
+		assert.nonEmptyArray(strings);
+
+		const value = strings[0];
+		function_(value);
+	}
+
+	{
+		const mixed = ['🦄', 'unicorn', 1, 2];
+		const function_ = (value: string | number) => value;
+
+		assert.nonEmptyArray(mixed);
+
+		const value = mixed[0];
+		function_(value);
+	}
+
+	{
+		const arrays = [['🦄'], ['unicorn']];
+		const function_ = (value: string[]) => value;
+
+		assert.nonEmptyArray(arrays);
+
+		const value = arrays[0];
+		function_(value);
+	}
 });
 
 test('is.emptyString', t => {


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/is/issues/174

I hope these tests are enough to ensure that the type guard is working correctly.