### PR TITLE
Fix `is.nonEmptyArray()` type narrowing with `undefined`

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -388,7 +388,7 @@ is.oddInteger = isAbsoluteMod2(1);
 
 is.emptyArray = (value: unknown): value is never[] => is.array(value) && value.length === 0;
 
-is.nonEmptyArray = <T = unknown, Item = unknown>(value: T | Item[]): value is (T extends Item[] ? [Item, ...Item[]] : T) => is.array(value) && value.length > 0;
+is.nonEmptyArray = <T = unknown, Item = unknown>(value: T | Item[]): value is [Item, ...Item[]] => is.array(value) && value.length > 0;
 
 is.emptyString = (value: unknown): value is '' => is.string(value) && value.length === 0;
 
@@ -584,7 +584,7 @@ type Assert = {
 	nodeStream: (value: unknown) => asserts value is NodeStream;
 	infinite: (value: unknown) => asserts value is number;
 	emptyArray: (value: unknown) => asserts value is never[];
-	nonEmptyArray: <T = unknown, Item = unknown>(value: T | Item[]) => asserts value is (T extends Item[] ? [Item, ...Item[]] : T);
+	nonEmptyArray: <T = unknown, Item = unknown>(value: T | Item[]) => asserts value is [Item, ...Item[]];
 	emptyString: (value: unknown) => asserts value is '';
 	emptyStringOrWhitespace: (value: unknown) => asserts value is string;
 	nonEmptyString: (value: unknown) => asserts value is string;
@@ -692,7 +692,7 @@ export const assert: Assert = {
 	nodeStream: (value: unknown): asserts value is NodeStream => assertType(is.nodeStream(value), AssertionTypeDescription.nodeStream, value),
 	infinite: (value: unknown): asserts value is number => assertType(is.infinite(value), AssertionTypeDescription.infinite, value),
 	emptyArray: (value: unknown): asserts value is never[] => assertType(is.emptyArray(value), AssertionTypeDescription.emptyArray, value),
-	nonEmptyArray: <T = unknown, Item = unknown>(value: T | Item[]): asserts value is (T extends Item[] ? [Item, ...Item[]] : T) => assertType(is.nonEmptyArray(value), AssertionTypeDescription.nonEmptyArray, value),
+	nonEmptyArray: <T = unknown, Item = unknown>(value: T | Item[]): asserts value is [Item, ...Item[]] => assertType(is.nonEmptyArray(value), AssertionTypeDescription.nonEmptyArray, value),
 	emptyString: (value: unknown): asserts value is '' => assertType(is.emptyString(value), AssertionTypeDescription.emptyString, value),
 	emptyStringOrWhitespace: (value: unknown): asserts value is string => assertType(is.emptyStringOrWhitespace(value), AssertionTypeDescription.emptyStringOrWhitespace, value),
 	nonEmptyString: (value: unknown): asserts value is string => assertType(is.nonEmptyString(value), AssertionTypeDescription.nonEmptyString, value),

--- a/test/test.ts
+++ b/test/test.ts
@@ -1626,7 +1626,7 @@ test('is.nonEmptyArray', t => {
 	});
 
 	{
-		const strings = ['🦄', 'unicorn'];
+		const strings = ['🦄', 'unicorn'] as string[] | undefined;
 		const function_ = (value: string) => value;
 
 		if (is.nonEmptyArray(strings)) {
@@ -1656,7 +1656,7 @@ test('is.nonEmptyArray', t => {
 	}
 
 	{
-		const strings = ['🦄', 'unicorn'];
+		const strings = ['🦄', 'unicorn'] as string[] | undefined;
 		const function_ = (value: string) => value;
 
 		assert.nonEmptyArray(strings);


### PR DESCRIPTION
Unfortunately the fix in https://github.com/sindresorhus/is/pull/185 doesn't work correctly with `undefined` values.

There seems to be no need for the conditional, and this produces the same behavior as the normal `is.array()` type guard.