### PR TITLE
Drop node v14 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,6 @@ jobs:
         node-version:
           - 18
           - 16
-          - 14
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"default": "./dist/index.js"
 	},
 	"engines": {
-		"node": ">=14.16"
+		"node": ">=16"
 	},
 	"scripts": {
 		"build": "del dist && tsc",


### PR DESCRIPTION
I couldn't reopen #182 so I'm opening a new PR.

I was just trying to use the `at` method on an array but couldn't do it because it requires node v16. It will be nice to be able to use more modern features in the future.

