### PR TITLE
Rename domElement to htmlElement

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -476,7 +476,7 @@ Check if `value` (number) is in the range of `0` to `upperBound`.
 is.inRange(3, 10);
 ```
 
-##### .domElement(value)
+##### .htmlElement(value)
 
 Returns `true` if `value` is an [HTMLElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement).
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -138,7 +138,7 @@ export type AssertionTypeDescription = typeof assertionTypeDescriptions[number];
 const getObjectType = (value: unknown): ObjectTypeName | undefined => {
 	const objectTypeName = Object.prototype.toString.call(value).slice(8, -1);
 
-	if (/HTML\w+Element/.test(objectTypeName) && isDomElement(value)) {
+	if (/HTML\w+Element/.test(objectTypeName) && isHtmlElement(value)) {
 		return 'HTMLElement';
 	}
 
@@ -240,7 +240,8 @@ const is = Object.assign(
 		date: isDate,
 		detect,
 		directInstanceOf: isDirectInstanceOf,
-		domElement: isDomElement,
+		/** @deprecated Renamed to `htmlElement` */
+		domElement: isHtmlElement,
 		emptyArray: isEmptyArray,
 		emptyMap: isEmptyMap,
 		emptyObject: isEmptyObject,
@@ -259,6 +260,7 @@ const is = Object.assign(
 		function_: isFunction,
 		generator: isGenerator,
 		generatorFunction: isGeneratorFunction,
+		htmlElement: isHtmlElement,
 		infinite: isInfinite,
 		inRange: isInRange,
 		int16Array: isInt16Array,
@@ -493,7 +495,7 @@ const DOM_PROPERTIES_TO_CHECK: Array<(keyof HTMLElement)> = [
 	'nodeValue',
 ];
 
-export function isDomElement(value: unknown): value is HTMLElement {
+export function isHtmlElement(value: unknown): value is HTMLElement {
 	return isObject(value)
 		&& (value as HTMLElement).nodeType === NODE_TYPE_ELEMENT
 		&& isString((value as HTMLElement).nodeName)
@@ -889,7 +891,9 @@ type Assert = {
 	typedArray: (value: unknown) => asserts value is TypedArray;
 	arrayLike: <T = unknown>(value: unknown) => asserts value is ArrayLike<T>;
 	tupleLike: <T extends Array<TypeGuard<unknown>>>(value: unknown, guards: [...T]) => asserts value is ResolveTypesOfTypeGuardsTuple<T>;
+	/** @deprecated Renamed to `htmlElement` */
 	domElement: (value: unknown) => asserts value is HTMLElement;
+	htmlElement: (value: unknown) => asserts value is HTMLElement;
 	observable: (value: unknown) => asserts value is ObservableLike;
 	nodeStream: (value: unknown) => asserts value is NodeStream;
 	infinite: (value: unknown) => asserts value is number;
@@ -946,7 +950,7 @@ export const assert: Assert = {
 	dataView: assertDataView,
 	date: assertDate,
 	directInstanceOf: assertDirectInstanceOf,
-	domElement: assertDomElement,
+	domElement: assertHtmlElement,
 	emptyArray: assertEmptyArray,
 	emptyMap: assertEmptyMap,
 	emptyObject: assertEmptyObject,
@@ -964,6 +968,7 @@ export const assert: Assert = {
 	function_: assertFunction,
 	generator: assertGenerator,
 	generatorFunction: assertGeneratorFunction,
+	htmlElement: assertHtmlElement,
 	infinite: assertInfinite,
 	inRange: assertInRange,
 	int16Array: assertInt16Array,
@@ -1038,6 +1043,7 @@ const methodTypeMap = {
 	isDataView: 'DataView',
 	isDate: 'Date',
 	isDirectInstanceOf: 'T',
+	/** @deprecated */
 	isDomElement: 'HTMLElement',
 	isEmptyArray: 'empty array',
 	isEmptyMap: 'empty map',
@@ -1055,6 +1061,7 @@ const methodTypeMap = {
 	isFunction: 'Function',
 	isGenerator: 'Generator',
 	isGeneratorFunction: 'GeneratorFunction',
+	isHtmlElement: 'HTMLElement',
 	isInfinite: 'infinite number',
 	isInRange: 'in range',
 	isInt16Array: 'Int16Array',
@@ -1250,12 +1257,6 @@ export function assertDirectInstanceOf<T>(instance: unknown, class_: Class<T>): 
 	}
 }
 
-export function assertDomElement(value: unknown): asserts value is HTMLElement {
-	if (!isDomElement(value)) {
-		throw new TypeError(typeErrorMessage('HTMLElement', value));
-	}
-}
-
 export function assertEmptyArray(value: unknown): asserts value is never[] {
 	if (!isEmptyArray(value)) {
 		throw new TypeError(typeErrorMessage('empty array', value));
@@ -1350,6 +1351,12 @@ export function assertGenerator(value: unknown): asserts value is Generator {
 export function assertGeneratorFunction(value: unknown): asserts value is GeneratorFunction {
 	if (!isGeneratorFunction(value)) {
 		throw new TypeError(typeErrorMessage('GeneratorFunction', value));
+	}
+}
+
+export function assertHtmlElement(value: unknown): asserts value is HTMLElement {
+	if (!isHtmlElement(value)) {
+		throw new TypeError(typeErrorMessage('HTMLElement', value));
 	}
 }
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -23,7 +23,6 @@ class ErrorSubclassFixture extends Error {}
 
 const {window} = new JSDOM();
 const {document} = window;
-const createDomElement = (element: string) => document.createElement(element);
 
 const structuredClone = globalThis.structuredClone ?? (x => x);
 
@@ -516,9 +515,9 @@ const types = new Map<string, Test>([
 		typename: 'number',
 		typeDescription: 'integer',
 	}],
-	['domElement', {
-		is: is.domElement,
-		assert: assert.domElement,
+	['htmlElement', {
+		is: is.htmlElement,
+		assert: assert.htmlElement,
 		fixtures: [
 			'div',
 			'input',
@@ -527,14 +526,14 @@ const types = new Map<string, Test>([
 			'canvas',
 			'script',
 		]
-			.map(fixture => createDomElement(fixture)),
+			.map(fixture => document.createElement(fixture)),
 		typeDescription: 'HTMLElement',
 	}],
-	['non-domElements', {
-		is: value => !is.domElement(value),
+	['non-htmlElement', {
+		is: value => !is.htmlElement(value),
 		assert(value: unknown) {
 			invertAssertThrow('HTMLElement', () => {
-				assert.domElement(value);
+				assert.htmlElement(value);
 			}, value);
 		},
 		fixtures: [
@@ -1622,11 +1621,11 @@ test('is.inRange', t => {
 	});
 });
 
-test('is.domElement', t => {
-	testType(t, 'domElement');
-	t.false(is.domElement({nodeType: 1, nodeName: 'div'}));
+test('is.htmlElement', t => {
+	testType(t, 'htmlElement');
+	t.false(is.htmlElement({nodeType: 1, nodeName: 'div'}));
 	t.throws(() => {
-		assert.domElement({nodeType: 1, nodeName: 'div'});
+		assert.htmlElement({nodeType: 1, nodeName: 'div'});
 	});
 
 	const tagNames = [
@@ -1636,11 +1635,11 @@ test('is.domElement', t => {
 		'img',
 		'canvas',
 		'script',
-	];
+	] as const;
 
 	for (const tagName of tagNames) {
-		const domElement = createDomElement(tagName);
-		t.is(is(domElement), 'HTMLElement');
+		const element = document.createElement(tagName);
+		t.is(is(element), 'HTMLElement');
 	}
 });
 


### PR DESCRIPTION
It seems like `isHtmlElement` is a better description for a method that determines if something is of type `HTMLElement`.

I didn't export a copy of `isHtmlElement` as `isDomElement`, I can add it if you'd prefer.
