### PR TITLE
Add main entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"url": "https://sindresorhus.com"
 	},
 	"type": "module",
+	"main": "./dist/index.js",
 	"exports": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"engines": {


### PR DESCRIPTION
- without the main entry, the index file cannot always be found implicitly