### PR TITLE
feat: ensure there's at least 1 char in non-empty string

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -4,6 +4,7 @@ import type {
 	Class,
 	Falsy,
 	NodeStream,
+	NonEmptyString,
 	ObservableLike,
 	Predicate,
 	Primitive,
@@ -582,12 +583,12 @@ export function isNonEmptySet<T = unknown>(value: unknown): value is Set<T> {
 }
 
 // TODO: Use `not ''` when the `not` operator is available.
-export function isNonEmptyString(value: unknown): value is string {
+export function isNonEmptyString(value: unknown): value is NonEmptyString {
 	return isString(value) && value.length > 0;
 }
 
 // TODO: Use `not ''` when the `not` operator is available.
-export function isNonEmptyStringAndNotWhitespace(value: unknown): value is string {
+export function isNonEmptyStringAndNotWhitespace(value: unknown): value is NonEmptyString {
 	return isString(value) && !isEmptyStringOrWhitespace(value);
 }
 

--- a/source/types.ts
+++ b/source/types.ts
@@ -73,3 +73,5 @@ export type NodeStream = {
 } & NodeJS.EventEmitter;
 
 export type Predicate = (value: unknown) => boolean;
+
+export type NonEmptyString = string & {0: string};


### PR DESCRIPTION
This is useful e.g. when trying to leverage a non-empty string for accessing its first character. We can say there's always at least 1 char in non-empty string so this allows us to do `s[0]` with TS option `noUncheckedIndexedAccess: true`.