### PR TITLE
Add `.validDate()`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -578,13 +578,29 @@ is.all(is.string, '🦄', [], 'unicorns');
 
 Returns `true` if the value is a valid date.
 
-`Invalid Date`s occur when an invalid value is passed to the `Date` constructor. This can be an invalid date string, a non-numeric value or a number that is outside of the expected range for a date value.
+All [`Date`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date) objects have an internal timestamp value which is the number of milliseconds since the [Unix epoch](https://developer.mozilla.org/en-US/docs/Glossary/Unix_time). When a new `Date` is constructed with bad inputs, no error is thrown. Instead, a new `Date` object is returned. But the internal timestamp value is set to `NaN`, which is an _'Invalid Date'_. Bad inputs can be an non-parsable date string, a non-numeric value or a number that is outside of the expected range for a date value.
 
 ```js
-is.validDate(new Date());
+const valid = new Date('2000-01-01');
+
+is.date(valid);
+//=> true
+valid.getTime();
+//=> 946684800000
+valid.toUTCString();
+//=> 'Sat, 01 Jan 2000 00:00:00 GMT'
+is.validDate(valid);
 //=> true
 
-is.validDate(new Date('unicorn'));
+const invalid = new Date('Not a parsable date string');
+
+is.date(invalid);
+//=> true
+invalid.getTime();
+//=> NaN
+invalid.toUTCString();
+//=> 'Invalid Date'
+is.validDate(invalid);
 //=> false
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -578,7 +578,7 @@ is.all(is.string, '🦄', [], 'unicorns');
 
 Returns `true` if the value is a valid date.
 
-All [`Date`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date) objects have an internal timestamp value which is the number of milliseconds since the [Unix epoch](https://developer.mozilla.org/en-US/docs/Glossary/Unix_time). When a new `Date` is constructed with bad inputs, no error is thrown. Instead, a new `Date` object is returned. But the internal timestamp value is set to `NaN`, which is an _'Invalid Date'_. Bad inputs can be an non-parsable date string, a non-numeric value or a number that is outside of the expected range for a date value.
+All [`Date`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date) objects have an internal timestamp value which is the number of milliseconds since the [Unix epoch](https://developer.mozilla.org/en-US/docs/Glossary/Unix_time). When a new `Date` is constructed with bad inputs, no error is thrown. Instead, a new `Date` object is returned. But the internal timestamp value is set to `NaN`, which is an `'Invalid Date'`. Bad inputs can be an non-parsable date string, a non-numeric value or a number that is outside of the expected range for a date value.
 
 ```js
 const valid = new Date('2000-01-01');

--- a/readme.md
+++ b/readme.md
@@ -574,6 +574,20 @@ is.all(is.string, '🦄', [], 'unicorns');
 //=> false
 ```
 
+##### .validDate(value)
+
+Returns `true` if the value is a valid date.
+
+`Invalid Date`s occur when an invalid value is passed to the `Date` constructor. This can be an invalid date string, a non-numeric value or a number that is outside of the expected range for a date value.
+
+```js
+is.validDate(new Date());
+//=> true
+
+is.validDate(new Date('unicorn'));
+//=> false
+```
+
 ##### .validLength(value)
 
 Returns `true` if the value is a safe integer that is greater than or equal to zero.

--- a/source/index.ts
+++ b/source/index.ts
@@ -128,6 +128,7 @@ const assertionTypeDescriptions = [
 	'in range',
 	'predicate returns truthy for any value',
 	'predicate returns truthy for all values',
+	'valid Date',
 	'valid length',
 	'whitespace string',
 	...objectTypeNames,
@@ -311,6 +312,7 @@ const is = Object.assign(
 		urlInstance: isUrlInstance,
 		urlSearchParams: isUrlSearchParams,
 		urlString: isUrlString,
+		validDate: isValidDate,
 		validLength: isValidLength,
 		weakMap: isWeakMap,
 		weakRef: isWeakRef,
@@ -760,6 +762,10 @@ export function isUrlString(value: unknown): value is string {
 	}
 }
 
+export function isValidDate(value: unknown): value is Date {
+	return isDate(value) && !isNan(Number(value));
+}
+
 export function isValidLength(value: unknown): value is number {
 	return isSafeInteger(value) && value >= 0;
 }
@@ -917,6 +923,7 @@ type Assert = {
 	propertyKey: (value: unknown) => asserts value is PropertyKey;
 	formData: (value: unknown) => asserts value is FormData;
 	urlSearchParams: (value: unknown) => asserts value is URLSearchParams;
+	validDate: (value: unknown) => asserts value is Date;
 	validLength: (value: unknown) => asserts value is number;
 	whitespaceString: (value: unknown) => asserts value is string;
 
@@ -1022,6 +1029,7 @@ export const assert: Assert = {
 	urlInstance: assertUrlInstance,
 	urlSearchParams: assertUrlSearchParams,
 	urlString: assertUrlString,
+	validDate: assertValidDate,
 	validLength: assertValidLength,
 	weakMap: assertWeakMap,
 	weakRef: assertWeakRef,
@@ -1114,6 +1122,7 @@ const methodTypeMap = {
 	isUrlInstance: 'URL',
 	isUrlSearchParams: 'URLSearchParams',
 	isUrlString: 'string with a URL',
+	isValidDate: 'valid Date',
 	isValidLength: 'valid length',
 	isWeakMap: 'WeakMap',
 	isWeakRef: 'WeakRef',
@@ -1648,6 +1657,12 @@ export function assertUrlSearchParams(value: unknown): asserts value is URLSearc
 export function assertUrlString(value: unknown): asserts value is string {
 	if (!isUrlString(value)) {
 		throw new TypeError(typeErrorMessage('string with a URL', value));
+	}
+}
+
+export function assertValidDate(value: unknown): asserts value is Date {
+	if (!isValidDate(value)) {
+		throw new TypeError(typeErrorMessage('valid Date', value));
 	}
 }
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -2101,6 +2101,17 @@ test('is.urlSearchParams', t => {
 	});
 });
 
+test('is.validDate', t => {
+	t.true(is.validDate(new Date()));
+	t.false(is.validDate(new Date('x')));
+	t.notThrows(() => {
+		assert.validDate(new Date());
+	});
+	t.throws(() => {
+		assert.validDate(new Date('x'));
+	});
+});
+
 test('is.validLength', t => {
 	t.true(is.validLength(1));
 	t.true(is.validLength(0));


### PR DESCRIPTION
This PR adds a new `.validDate()` function. It returns `true` if the passed value is a valid date. 

`Invalid Date`s occur when an invalid value is passed to the `Date` constructor. This can be an invalid date string, a non-numeric value or a number that is outside of the expected range for a date value. `Invalid Date`s are tecnically `Date`s, but not very useful. 

For more details on invalid `Invalid Date`s, see [_The epoch, timestamps, and invalid date_ on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#the_epoch_timestamps_and_invalid_date). 