### PR TITLE
chore: replace ts-node with tsimp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 yarn.lock
 dist
+.tsimp

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 	},
 	"scripts": {
 		"build": "del dist && tsc",
-		"test": "tsc --noEmit && xo && NODE_OPTIONS='--loader=ts-node/esm --no-warnings=ExperimentalWarning' ava",
+		"test": "tsc --noEmit && xo && ava",
 		"prepare": "npm run build"
 	},
 	"files": [
@@ -50,24 +50,30 @@
 		"types"
 	],
 	"devDependencies": {
-		"@sindresorhus/tsconfig": "^4.0.0",
-		"@types/jsdom": "^21.1.1",
-		"@types/node": "^20.5.0",
+		"@sindresorhus/tsconfig": "^5.0.0",
+		"@types/jsdom": "^21.1.7",
+		"@types/node": "^20.14.8",
 		"@types/zen-observable": "^0.8.3",
-		"ava": "^5.3.1",
+		"ava": "^6.1.3",
 		"del-cli": "^5.0.0",
+		"expect-type": "^0.16.0",
 		"jsdom": "^22.1.0",
 		"rxjs": "^7.8.1",
 		"tempy": "^3.1.0",
-		"ts-node": "^10.9.1",
+		"tsimp": "^2.0.11",
 		"typescript": "^5.1.6",
 		"xo": "^0.56.0",
-		"zen-observable": "^0.10.0",
-		"expect-type": "^0.16.0"
+		"zen-observable": "^0.10.0"
 	},
 	"ava": {
+		"environmentVariables": {
+			"TSIMP_DIAG": "error"
+		},
 		"extensions": {
 			"ts": "module"
-		}
+		},
+		"nodeArguments": [
+			"--import=tsimp/import"
+		]
 	}
 }

--- a/test/test.ts
+++ b/test/test.ts
@@ -764,13 +764,13 @@ test('is.array', t => {
 	t.notThrows(() => {
 		const x: unknown[] = [1, 2, 3];
 		assert.array(x, assert.number);
-		x[0].toFixed(0);
+		x[0]?.toFixed(0);
 	});
 
 	t.notThrows(() => {
 		const x: unknown[] = [1, 2, 3];
 		if (is.array<number>(x, is.number)) {
-			x[0].toFixed(0);
+			x[0]?.toFixed(0);
 		}
 	});
 });
@@ -1174,7 +1174,7 @@ test('is.falsy', t => {
 	// Checks that `assert.falsy` narrow downs boolean type to `false`.
 	{
 		const booleans = [false, true];
-		const function_ = (value: false) => value;
+		const function_ = (value?: false) => value;
 		assert.falsy(booleans[0]);
 		function_(booleans[0]);
 	}
@@ -1182,7 +1182,7 @@ test('is.falsy', t => {
 	// Checks that `assert.falsy` narrow downs number type to `0`.
 	{
 		const bits = [0, -0, 1];
-		const function_ = (value: 0) => value;
+		const function_ = (value?: 0) => value;
 		assert.falsy(bits[0]);
 		function_(bits[0]);
 		assert.falsy(bits[1]);
@@ -1192,7 +1192,7 @@ test('is.falsy', t => {
 	// Checks that `assert.falsy` narrow downs bigint type to `0n`.
 	{
 		const bits = [0n, -0n, 1n];
-		const function_ = (value: 0n) => value;
+		const function_ = (value?: 0n) => value;
 		assert.falsy(bits[0]);
 		function_(bits[0]);
 		assert.falsy(bits[1]);
@@ -1202,7 +1202,7 @@ test('is.falsy', t => {
 	// Checks that `assert.falsy` narrow downs string type to empty string.
 	{
 		const strings = ['', 'nonEmpty'];
-		const function_ = (value: '') => value;
+		const function_ = (value?: '') => value;
 		assert.falsy(strings[0]);
 		function_(strings[0]);
 	}
@@ -1219,7 +1219,7 @@ test('is.falsy', t => {
 	{
 		const maybeNulls = [null, Symbol('🦄')];
 		// eslint-disable-next-line @typescript-eslint/ban-types
-		const function_ = (value: null) => value;
+		const function_ = (value?: null) => value;
 		assert.falsy(maybeNulls[0]);
 		function_(maybeNulls[0]);
 	}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,9 +6,4 @@
 	"include": [
 		"source"
 	],
-	"ts-node": {
-		"transpileOnly": true,
-		"files": true,
-		"experimentalResolver": true
-	}
 }


### PR DESCRIPTION
A while back [I updated the test environment to use node v20](https://github.com/sindresorhus/is/pull/181) and you said you'd prefer to use `environmentVariables` for AVA configuration but it didn't work. I said that we could clean up the ugly config once it's fixed upstream, but it doesn't look like `ts-node` has made any progress in that regard.

AVA itself is now recommending `tsimp` so I replaced `ts-node` with that and was able to clean up our config a little bit.

One benefit of using `tsimp` is that it typechecks our test file as well without it needing to be referenced in our `tsconfig.json`, there were a few minor issues in there that it brought up, so I addressed those.