### PR TITLE
Fix passing in assertion message to `assertArray`

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -1149,11 +1149,10 @@ export function assertArray<T = unknown>(value: unknown, assertion?: (element: u
 	}
 
 	if (assertion) {
-		// eslint-disable-next-line unicorn/no-array-for-each
-		value.forEach(v => {
+		for (const element of value) {
 			// @ts-expect-error: "Assertions require every name in the call target to be declared with an explicit type annotation."
-			assertion(v, message);
-		});
+			assertion(element, message);
+		}
 	}
 }
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -1143,14 +1143,17 @@ export function assertAny(predicate: Predicate | Predicate[], ...values: unknown
 	}
 }
 
-export function assertArray<T = unknown>(value: unknown, assertion?: (element: unknown) => asserts element is T, message?: string): asserts value is T[] {
+export function assertArray<T = unknown>(value: unknown, assertion?: (element: unknown, message?: string) => asserts element is T, message?: string): asserts value is T[] {
 	if (!isArray(value)) {
 		throw new TypeError(message ?? typeErrorMessage('Array', value));
 	}
 
 	if (assertion) {
-		// eslint-disable-next-line unicorn/no-array-for-each, unicorn/no-array-callback-reference
-		value.forEach(assertion);
+		// eslint-disable-next-line unicorn/no-array-for-each
+		value.forEach(v => {
+			// @ts-expect-error: "Assertions require every name in the call target to be declared with an explicit type annotation."
+			assertion(v, message);
+		});
 	}
 }
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -773,6 +773,10 @@ test('is.array', t => {
 			x[0]?.toFixed(0);
 		}
 	});
+
+	t.throws(() => {
+		assert.array([1, '2'], assert.number, 'Expected numbers');
+	}, {message: /Expected numbers/});
 });
 
 test('is.function', t => {


### PR DESCRIPTION
As `assertArray` previously called the assertion function in a `forEach(assertion)`, the index was passed as the custom message. This PR fixes this bug by passing down the `message` argument to the assertion function. 