### PR TITLE
Structure fixtures so they can be easily tested for exclusivity 

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -209,8 +209,12 @@ function detect(value: unknown): TypeName {
 	}
 
 	const tagType = getObjectType(value);
-	if (tagType) {
+	if (tagType && tagType !== 'Object') {
 		return tagType;
+	}
+
+	if (hasPromiseApi(value)) {
+		return 'Promise';
 	}
 
 	if (value instanceof String || value instanceof Boolean || value instanceof Number) {
@@ -1120,7 +1124,7 @@ const methodTypeMap = {
 	isWhitespaceString: 'whitespace string',
 } as const;
 
-function keysOf<T extends Record<PropertyKey, unknown>>(value: T): Array<keyof T> {
+export function keysOf<T extends Record<PropertyKey, unknown>>(value: T): Array<keyof T> {
 	return Object.keys(value) as Array<keyof T>;
 }
 

--- a/source/index.ts
+++ b/source/index.ts
@@ -11,6 +11,7 @@ import type {
 	WeakRef,
 	Whitespace,
 } from './types.js';
+import {keysOf} from './utilities.js';
 
 // From type-fest.
 type ExtractFromGlobalConstructors<Name extends string> =
@@ -1123,10 +1124,6 @@ const methodTypeMap = {
 	isWeakSet: 'WeakSet',
 	isWhitespaceString: 'whitespace string',
 } as const;
-
-export function keysOf<T extends Record<PropertyKey, unknown>>(value: T): Array<keyof T> {
-	return Object.keys(value) as Array<keyof T>;
-}
 
 type IsMethodName = keyof typeof methodTypeMap;
 const isMethodNames: IsMethodName[] = keysOf(methodTypeMap);

--- a/source/utilities.ts
+++ b/source/utilities.ts
@@ -1,0 +1,3 @@
+export function keysOf<T extends Record<PropertyKey, unknown>>(value: T): Array<keyof T> {
+	return Object.keys(value) as Array<keyof T>;
+}

--- a/test/test.ts
+++ b/test/test.ts
@@ -12,13 +12,13 @@ import {expectTypeOf} from 'expect-type';
 import ZenObservable from 'zen-observable';
 import is, {
 	assert,
-	keysOf,
 	type AssertionTypeDescription,
 	type Predicate,
 	type Primitive,
 	type TypedArray,
 	type TypeName,
 } from '../source/index.js';
+import {keysOf} from '../source/utilities.js';
 
 class PromiseSubclassFixture<T> extends Promise<T> {}
 class ErrorSubclassFixture extends Error {}


### PR DESCRIPTION
Without extensive exclude declarations as specified in the TODO message:

```
// TODO: Automatically exclude value types in other tests that we have in the current one.
// Could reduce the use of `exclude`.
```

I identified each unique entry in the fixtures and, if they were reused across multiple types, hoisted them to the top and spread them into the fixtures. This allows us to filter out fixture values that have already been tested as being of the type under test. It becomes more declarative in the fixture definitions, rather than in the call site of the test.

I split the primitive type fixtures from the object type fixtures so that we can exclude all the entries that are not primitives without needing redundant properties in the fixture data.

Another structural change to the fixtures was changing the fixtures from a Map to a readonly object so that we can use the keys to access the `is` methods that we are testing. This removed 2 redundant lines from each fixture.

I also iterate over the method names defined in the fixtures to ensure that everything listed is tested. Previously every fixture was used manually and needed to be added to a test after it was created.

If a method name has additional tests beyond the exclusive fixture based test, I labelled it as supplemental.

There was one tricky bit in there with `Buffer` and `Uint8Array` being the same thing so I added an exclusion there.

⚠️ There was one small functional change that I added regarding the Promise type. I think we should prefer the `Promise` type over `Object` when it has the promise API. It seems strange that we would expect the typeDescription to be `Promise`, but the typeName would be `Object`. If you think we should leave it as is, I can probably create an exclusion for it.